### PR TITLE
feat(security): model boundary enforcement

### DIFF
--- a/src/swe_team/model_boundary.py
+++ b/src/swe_team/model_boundary.py
@@ -1,0 +1,133 @@
+"""
+Model boundary enforcement for SWE-Squad code generation.
+
+SEC-68: kimi-k2.5 was used for unauthorized code generation via OpenClaw.
+This module ensures ONLY Claude models are used for code generation tasks.
+Non-Claude models (gemini, kimi, opencode, etc.) are restricted to
+read-only tasks: investigation, review, search, dashboard.
+
+Violation of model boundaries is logged as a CRITICAL security event.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import FrozenSet, Optional
+
+logger = logging.getLogger(__name__)
+
+# Models authorized for CODE GENERATION (writing/editing code, creating PRs)
+AUTHORIZED_CODE_MODELS: FrozenSet[str] = frozenset({
+    "haiku",
+    "sonnet",
+    "opus",
+    "claude-haiku",
+    "claude-sonnet",
+    "claude-opus",
+    "claude-3-haiku",
+    "claude-3-sonnet",
+    "claude-3-opus",
+    "claude-3.5-haiku",
+    "claude-3.5-sonnet",
+    "claude-4-haiku",
+    "claude-4-sonnet",
+    "claude-4-opus",
+})
+
+# Pattern to match any Claude model variant
+_CLAUDE_PATTERN = re.compile(r"^(claude|haiku|sonnet|opus)", re.IGNORECASE)
+
+# Models explicitly BLOCKED — known to have caused incidents
+BLOCKED_MODELS: FrozenSet[str] = frozenset({
+    "kimi",
+    "kimi-k2",
+    "kimi-k2.5",
+    "kimi-k2.5:cloud",
+    "moonshot",
+})
+
+# Tasks that require Claude (code generation, PR creation, merging)
+CODE_GENERATION_TASKS: FrozenSet[str] = frozenset({
+    "fix",
+    "develop",
+    "implement",
+    "code_review",
+    "pr_create",
+    "merge",
+    "refactor",
+    "write_test",
+})
+
+# Tasks allowed for non-Claude models (read-only, no code changes)
+READ_ONLY_TASKS: FrozenSet[str] = frozenset({
+    "investigate",
+    "review",
+    "search",
+    "dashboard",
+    "websearch",
+    "summarize",
+    "triage",
+})
+
+
+def is_claude_model(model: str) -> bool:
+    """Check if a model string refers to a Claude model."""
+    return bool(_CLAUDE_PATTERN.match(model.strip()))
+
+
+def validate_model_for_task(model: str, task: str) -> tuple[bool, str]:
+    """Validate that the given model is authorized for the given task.
+
+    Returns (allowed, reason). If not allowed, reason explains why.
+    """
+    model_lower = model.strip().lower()
+
+    # Explicitly blocked models — NEVER allowed for anything
+    for blocked in BLOCKED_MODELS:
+        if blocked in model_lower:
+            logger.critical(
+                "SEC-68 BLOCKED MODEL: '%s' attempted for task '%s' — "
+                "this model caused a security incident and is permanently banned",
+                model, task,
+            )
+            return False, f"Model '{model}' is permanently blocked (SEC-68 incident)"
+
+    # Code generation tasks REQUIRE Claude
+    task_lower = task.strip().lower()
+    if task_lower in CODE_GENERATION_TASKS or "code" in task_lower or "fix" in task_lower or "develop" in task_lower:
+        if not is_claude_model(model):
+            logger.critical(
+                "SEC-68 MODEL BOUNDARY VIOLATION: non-Claude model '%s' "
+                "attempted for code generation task '%s' — DENIED",
+                model, task,
+            )
+            return False, (
+                f"Model '{model}' is not authorized for code generation. "
+                f"Only Claude models are permitted for task '{task}'"
+            )
+
+    # Read-only tasks — any model is fine (gemini for investigation, etc.)
+    if task_lower in READ_ONLY_TASKS:
+        return True, "ok"
+
+    # Unknown task — default to Claude-only (fail-secure)
+    if not is_claude_model(model):
+        logger.warning(
+            "SEC-68: Unknown task '%s' with non-Claude model '%s' — "
+            "defaulting to DENY (fail-secure)",
+            task, model,
+        )
+        return False, f"Unknown task '{task}' requires Claude model (fail-secure default)"
+
+    return True, "ok"
+
+
+def enforce_code_generation_boundary(model: str, task: str = "develop") -> str:
+    """Enforce model boundary — returns the model if allowed, raises ValueError if not.
+
+    Use this as a gate before any subprocess call that generates code.
+    """
+    allowed, reason = validate_model_for_task(model, task)
+    if not allowed:
+        raise ValueError(f"MODEL BOUNDARY VIOLATION: {reason}")
+    return model

--- a/tests/unit/test_model_boundary.py
+++ b/tests/unit/test_model_boundary.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for model boundary enforcement (SEC-68).
+
+Validates that:
+- Only Claude models can do code generation
+- kimi-k2.5 and other blocked models are always rejected
+- Read-only tasks (investigate, review) allow non-Claude models
+- Unknown tasks default to Claude-only (fail-secure)
+"""
+from __future__ import annotations
+
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.swe_team.model_boundary import (
+    is_claude_model,
+    validate_model_for_task,
+    enforce_code_generation_boundary,
+    AUTHORIZED_CODE_MODELS,
+    BLOCKED_MODELS,
+)
+
+
+class TestIsClaudeModel(unittest.TestCase):
+    """Test Claude model identification."""
+
+    def test_haiku_is_claude(self):
+        assert is_claude_model("haiku")
+
+    def test_sonnet_is_claude(self):
+        assert is_claude_model("sonnet")
+
+    def test_opus_is_claude(self):
+        assert is_claude_model("opus")
+
+    def test_claude_3_sonnet_is_claude(self):
+        assert is_claude_model("claude-3-sonnet")
+
+    def test_claude_prefix_is_claude(self):
+        assert is_claude_model("claude-4-opus")
+
+    def test_kimi_is_not_claude(self):
+        assert not is_claude_model("kimi-k2.5")
+
+    def test_gemini_is_not_claude(self):
+        assert not is_claude_model("gemini-2.5-flash")
+
+    def test_gpt_is_not_claude(self):
+        assert not is_claude_model("gpt-4o")
+
+    def test_empty_string(self):
+        assert not is_claude_model("")
+
+    def test_case_insensitive(self):
+        assert is_claude_model("Claude-3-Sonnet")
+        assert is_claude_model("HAIKU")
+
+
+class TestValidateModelForTask(unittest.TestCase):
+    """Test model-task validation matrix."""
+
+    # Code generation tasks — Claude only
+    def test_claude_for_develop_allowed(self):
+        allowed, _ = validate_model_for_task("sonnet", "develop")
+        assert allowed
+
+    def test_claude_for_fix_allowed(self):
+        allowed, _ = validate_model_for_task("haiku", "fix")
+        assert allowed
+
+    def test_gemini_for_develop_blocked(self):
+        allowed, reason = validate_model_for_task("gemini-flash", "develop")
+        assert not allowed
+        assert "not authorized" in reason.lower()
+
+    def test_kimi_for_develop_blocked(self):
+        allowed, reason = validate_model_for_task("kimi-k2.5", "develop")
+        assert not allowed
+        assert "blocked" in reason.lower() or "permanently" in reason.lower()
+
+    def test_kimi_for_investigate_also_blocked(self):
+        """kimi is permanently blocked for ALL tasks."""
+        allowed, reason = validate_model_for_task("kimi-k2.5:cloud", "investigate")
+        assert not allowed
+
+    # Read-only tasks — any non-blocked model OK
+    def test_gemini_for_investigate_allowed(self):
+        allowed, _ = validate_model_for_task("gemini-flash", "investigate")
+        assert allowed
+
+    def test_gemini_for_review_allowed(self):
+        allowed, _ = validate_model_for_task("gemini-flash", "review")
+        assert allowed
+
+    def test_gemini_for_search_allowed(self):
+        allowed, _ = validate_model_for_task("gemini-flash", "search")
+        assert allowed
+
+    # Unknown tasks — fail-secure (Claude only)
+    def test_unknown_task_claude_allowed(self):
+        allowed, _ = validate_model_for_task("sonnet", "some_new_task")
+        assert allowed
+
+    def test_unknown_task_gemini_blocked(self):
+        allowed, _ = validate_model_for_task("gemini-flash", "some_new_task")
+        assert not allowed
+
+
+class TestEnforceCodeGenerationBoundary(unittest.TestCase):
+    """Test the enforcement gate function."""
+
+    def test_claude_passes(self):
+        result = enforce_code_generation_boundary("sonnet", task="develop")
+        assert result == "sonnet"
+
+    def test_kimi_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            enforce_code_generation_boundary("kimi-k2.5", task="develop")
+        assert "MODEL BOUNDARY VIOLATION" in str(ctx.exception)
+
+    def test_gemini_for_code_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            enforce_code_generation_boundary("gemini-flash", task="fix")
+        assert "MODEL BOUNDARY VIOLATION" in str(ctx.exception)
+
+    def test_blocked_model_always_raises(self):
+        for model in BLOCKED_MODELS:
+            with self.assertRaises(ValueError, msg=f"{model} should be blocked"):
+                enforce_code_generation_boundary(model, task="investigate")
+
+
+class TestBlockedModels(unittest.TestCase):
+    """Ensure all known-bad models are in the blocklist."""
+
+    def test_kimi_variants_blocked(self):
+        for variant in ["kimi", "kimi-k2", "kimi-k2.5", "kimi-k2.5:cloud", "moonshot"]:
+            allowed, _ = validate_model_for_task(variant, "develop")
+            assert not allowed, f"{variant} should be blocked"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `src/swe_team/model_boundary.py` — whitelist-only code generation enforcement
- `AUTHORIZED_CODE_MODELS`: Claude model variants only
- `BLOCKED_MODELS`: permanently banned models
- `enforce_code_generation_boundary()` gate for developer/investigator
- 25 unit tests

## Test plan
```bash
python3 -m pytest tests/unit/test_model_boundary.py -v
```

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)