### PR TITLE
feat(security): RBAC agent rulebook

### DIFF
--- a/config/swe_team/roles.yaml
+++ b/config/swe_team/roles.yaml
@@ -1,0 +1,86 @@
+# Agent Role Definitions — RBAC enforcement for SWE-Squad
+# Deny-by-default: unlisted permissions are denied
+# Explicit deny wins over any grant
+
+roles:
+  claude-code:
+    description: "Primary coding and orchestration agent"
+    enabled: true
+    permissions:
+      - code_generation
+      - code_review
+      - pr_create
+      - pr_merge
+      - investigation
+      - orchestration
+      - commit
+      - branch_create
+      - triage
+      - summarization
+      - search
+      - dashboard
+    models: [haiku, sonnet, opus]
+    merge_policy:
+      cooldown_minutes: 30
+      require_human_approval: true
+      self_merge: false
+
+  gemini-cli:
+    description: "Investigation and summarization agent (read-only)"
+    enabled: true
+    permissions:
+      - investigation
+      - summarization
+      - triage
+      - search
+      - dashboard
+      - websearch
+    deny:
+      - code_generation
+      - pr_create
+      - pr_merge
+      - commit
+      - branch_create
+      - code_review
+    models: [gemini-2.5-flash-thinking, gemini-2.5-pro]
+
+  openclaw:
+    description: "Communication relay — messaging only"
+    enabled: true
+    permissions:
+      - messaging
+      - notification
+      - user_interaction
+      - ticket_intake
+    deny:
+      - code_generation
+      - code_review
+      - pr_create
+      - pr_merge
+      - commit
+      - investigation
+      - orchestration
+    models: []
+
+  opencode:
+    description: "Auxiliary agent (disabled by default)"
+    enabled: false
+    permissions:
+      - investigation
+      - code_review
+    deny:
+      - pr_merge
+      - orchestration
+    models: [deepseek-coder]
+
+overrides:
+  - rule: "LOW/MEDIUM bugs can be investigated by gemini-cli"
+    condition:
+      severity: [low, medium]
+      task: investigation
+    allow_agents: [gemini-cli]
+  - rule: "Only claude-code generates code"
+    condition:
+      task: [code_generation, commit, pr_create, pr_merge]
+    allow_agents: [claude-code]
+    enforce: strict

--- a/src/swe_team/agent_rbac.py
+++ b/src/swe_team/agent_rbac.py
@@ -1,0 +1,181 @@
+"""
+Role-Based Access Control for SWE-Squad agents.
+
+Loads role definitions from config/swe_team/roles.yaml and enforces
+permissions at every pipeline stage. Deny-by-default: if a permission
+is not explicitly granted, it is denied.
+
+SEC-68: This module exists because a rogue agent (OpenClaw) was able to
+generate code, create PRs, and self-merge without any permission check.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_ROLES_PATH = Path(__file__).resolve().parents[2] / "config" / "swe_team" / "roles.yaml"
+
+
+class PermissionDeniedError(Exception):
+    """Raised when an agent attempts an unauthorized action."""
+    pass
+
+
+class AgentRole:
+    """Parsed role definition for a single agent."""
+
+    def __init__(self, name: str, data: Dict[str, Any]):
+        self.name = name
+        self.description = data.get("description", "")
+        self.enabled = data.get("enabled", True)
+        self.permissions: set = set(data.get("permissions", []))
+        self.deny: set = set(data.get("deny", []))
+        self.models: List[str] = data.get("models", [])
+        self.merge_policy: Dict = data.get("merge_policy", {})
+
+    def has_permission(self, task: str) -> bool:
+        """Check if this role grants the given permission."""
+        if not self.enabled:
+            return False
+        # Explicit deny always wins
+        if task in self.deny:
+            return False
+        return task in self.permissions
+
+
+class RBACEngine:
+    """Loads roles and enforces permissions."""
+
+    def __init__(self, roles_path: Optional[Path] = None):
+        self._path = roles_path or _ROLES_PATH
+        self._roles: Dict[str, AgentRole] = {}
+        self._overrides: List[Dict] = []
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            logger.warning("RBAC roles file not found at %s — deny-by-default active", self._path)
+            return
+        try:
+            with open(self._path) as f:
+                data = yaml.safe_load(f) or {}
+            for name, role_data in data.get("roles", {}).items():
+                self._roles[name] = AgentRole(name, role_data)
+            self._overrides = data.get("overrides", [])
+            logger.info("RBAC loaded: %d roles, %d overrides", len(self._roles), len(self._overrides))
+        except Exception:
+            logger.exception("Failed to load RBAC roles — deny-by-default active")
+
+    def reload(self) -> None:
+        """Reload roles from disk."""
+        self._roles.clear()
+        self._overrides.clear()
+        self._load()
+
+    def get_role(self, agent_name: str) -> Optional[AgentRole]:
+        return self._roles.get(agent_name)
+
+    def list_roles(self) -> Dict[str, AgentRole]:
+        return dict(self._roles)
+
+    def check_permission(
+        self,
+        agent_name: str,
+        task: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[bool, str]:
+        """Check if agent_name is allowed to perform task.
+
+        Returns (allowed, reason).
+        Deny-by-default: unknown agents or unlisted permissions are denied.
+        """
+        context = context or {}
+
+        role = self._roles.get(agent_name)
+        if not role:
+            logger.warning("RBAC: unknown agent '%s' denied task '%s' (deny-by-default)", agent_name, task)
+            return False, f"Unknown agent '{agent_name}' — not in roles.yaml"
+
+        if not role.enabled:
+            return False, f"Agent '{agent_name}' is disabled in roles.yaml"
+
+        # Check explicit deny first
+        if task in role.deny:
+            logger.critical(
+                "RBAC DENIED: agent '%s' attempted '%s' — explicitly denied in roles.yaml",
+                agent_name, task,
+            )
+            return False, f"Agent '{agent_name}' is explicitly denied permission '{task}'"
+
+        # Check base permission
+        if role.has_permission(task):
+            return True, "granted"
+
+        # Check overrides
+        for override in self._overrides:
+            condition = override.get("condition", {})
+            allowed_agents = override.get("allow_agents", [])
+
+            if agent_name not in allowed_agents:
+                continue
+
+            # Check if task matches
+            task_cond = condition.get("task")
+            if task_cond:
+                tasks = task_cond if isinstance(task_cond, list) else [task_cond]
+                if task not in tasks:
+                    continue
+
+            # Check severity condition if present
+            sev_cond = condition.get("severity")
+            if sev_cond and context.get("severity"):
+                sevs = sev_cond if isinstance(sev_cond, list) else [sev_cond]
+                if context["severity"] not in sevs:
+                    continue
+
+            # Check enforce: strict (blocks everyone else)
+            if override.get("enforce") == "strict" and agent_name not in allowed_agents:
+                continue
+
+            logger.info("RBAC override: agent '%s' granted '%s' via rule '%s'",
+                        agent_name, task, override.get("rule", "unnamed"))
+            return True, f"granted via override: {override.get('rule', '')}"
+
+        # Deny by default
+        logger.warning("RBAC: agent '%s' denied task '%s' (not in permissions list)", agent_name, task)
+        return False, f"Agent '{agent_name}' does not have permission '{task}'"
+
+    def enforce(
+        self,
+        agent_name: str,
+        task: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Enforce permission — raises PermissionDeniedError if denied."""
+        allowed, reason = self.check_permission(agent_name, task, context)
+        if not allowed:
+            raise PermissionDeniedError(f"RBAC: {reason}")
+
+
+# Module-level singleton for convenience
+_engine: Optional[RBACEngine] = None
+
+
+def get_rbac_engine() -> RBACEngine:
+    global _engine
+    if _engine is None:
+        _engine = RBACEngine()
+    return _engine
+
+
+def check_permission(agent_name: str, task: str, context: Optional[Dict] = None) -> Tuple[bool, str]:
+    return get_rbac_engine().check_permission(agent_name, task, context)
+
+
+def enforce_permission(agent_name: str, task: str, context: Optional[Dict] = None) -> None:
+    get_rbac_engine().enforce(agent_name, task, context)

--- a/src/swe_team/agent_rbac.py
+++ b/src/swe_team/agent_rbac.py
@@ -26,7 +26,7 @@ class PermissionDeniedError(Exception):
     pass
 
 
-class AgentRole:
+class RBACRole:
     """Parsed role definition for a single agent."""
 
     def __init__(self, name: str, data: Dict[str, Any]):
@@ -53,7 +53,7 @@ class RBACEngine:
 
     def __init__(self, roles_path: Optional[Path] = None):
         self._path = roles_path or _ROLES_PATH
-        self._roles: Dict[str, AgentRole] = {}
+        self._roles: Dict[str, RBACRole] = {}
         self._overrides: List[Dict] = []
         self._load()
 
@@ -65,7 +65,7 @@ class RBACEngine:
             with open(self._path) as f:
                 data = yaml.safe_load(f) or {}
             for name, role_data in data.get("roles", {}).items():
-                self._roles[name] = AgentRole(name, role_data)
+                self._roles[name] = RBACRole(name, role_data)
             self._overrides = data.get("overrides", [])
             logger.info("RBAC loaded: %d roles, %d overrides", len(self._roles), len(self._overrides))
         except Exception:
@@ -77,10 +77,10 @@ class RBACEngine:
         self._overrides.clear()
         self._load()
 
-    def get_role(self, agent_name: str) -> Optional[AgentRole]:
+    def get_role(self, agent_name: str) -> Optional[RBACRole]:
         return self._roles.get(agent_name)
 
-    def list_roles(self) -> Dict[str, AgentRole]:
+    def list_roles(self) -> Dict[str, RBACRole]:
         return dict(self._roles)
 
     def check_permission(
@@ -112,12 +112,48 @@ class RBACEngine:
             )
             return False, f"Agent '{agent_name}' is explicitly denied permission '{task}'"
 
+        # Evaluate strict overrides before base permission check.
+        # If a strict override covers this task and the agent is NOT in allow_agents, deny immediately.
+        for override in self._overrides:
+            if override.get("enforce") != "strict":
+                continue
+
+            condition = override.get("condition", {})
+
+            # Check if task matches this override
+            task_cond = condition.get("task")
+            if task_cond:
+                tasks = task_cond if isinstance(task_cond, list) else [task_cond]
+                if task not in tasks:
+                    continue
+
+            # Missing severity must NOT match a severity-conditioned override
+            sev_cond = condition.get("severity")
+            if sev_cond:
+                if not context.get("severity"):
+                    continue
+                sevs = sev_cond if isinstance(sev_cond, list) else [sev_cond]
+                if context["severity"] not in sevs:
+                    continue
+
+            # This strict override applies to this task — enforce it
+            allowed_agents = override.get("allow_agents", [])
+            if agent_name not in allowed_agents:
+                logger.critical(
+                    "RBAC DENIED (strict override): agent '%s' attempted '%s' — rule '%s'",
+                    agent_name, task, override.get("rule", "unnamed"),
+                )
+                return False, f"Agent '{agent_name}' denied by strict override: {override.get('rule', '')}"
+
         # Check base permission
         if role.has_permission(task):
             return True, "granted"
 
-        # Check overrides
+        # Check non-strict overrides
         for override in self._overrides:
+            if override.get("enforce") == "strict":
+                continue
+
             condition = override.get("condition", {})
             allowed_agents = override.get("allow_agents", [])
 
@@ -131,16 +167,15 @@ class RBACEngine:
                 if task not in tasks:
                     continue
 
-            # Check severity condition if present
+            # Missing severity must NOT match a severity-conditioned override
+            if "severity" in condition and not context.get("severity"):
+                continue
+
             sev_cond = condition.get("severity")
             if sev_cond and context.get("severity"):
                 sevs = sev_cond if isinstance(sev_cond, list) else [sev_cond]
                 if context["severity"] not in sevs:
                     continue
-
-            # Check enforce: strict (blocks everyone else)
-            if override.get("enforce") == "strict" and agent_name not in allowed_agents:
-                continue
 
             logger.info("RBAC override: agent '%s' granted '%s' via rule '%s'",
                         agent_name, task, override.get("rule", "unnamed"))

--- a/tests/unit/test_agent_rbac.py
+++ b/tests/unit/test_agent_rbac.py
@@ -1,0 +1,279 @@
+"""Tests for Role-Based Access Control (agent_rbac.py)."""
+import os
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import yaml
+
+from src.swe_team.agent_rbac import (
+    AgentRole,
+    PermissionDeniedError,
+    RBACEngine,
+)
+
+
+def _write_roles(tmp_dir: str, content: str) -> Path:
+    p = Path(tmp_dir) / "roles.yaml"
+    p.write_text(textwrap.dedent(content))
+    return p
+
+
+FULL_ROLES_YAML = """\
+roles:
+  claude-code:
+    description: "Primary coding and orchestration agent"
+    enabled: true
+    permissions:
+      - code_generation
+      - code_review
+      - pr_create
+      - pr_merge
+      - investigation
+      - orchestration
+      - commit
+      - branch_create
+      - triage
+      - summarization
+      - search
+      - dashboard
+    models: [haiku, sonnet, opus]
+    merge_policy:
+      cooldown_minutes: 30
+      require_human_approval: true
+      self_merge: false
+
+  gemini-cli:
+    description: "Investigation and summarization agent (read-only)"
+    enabled: true
+    permissions:
+      - investigation
+      - summarization
+      - triage
+      - search
+      - dashboard
+      - websearch
+    deny:
+      - code_generation
+      - pr_create
+      - pr_merge
+      - commit
+      - branch_create
+      - code_review
+    models: [gemini-2.5-flash-thinking, gemini-2.5-pro]
+
+  openclaw:
+    description: "Communication relay"
+    enabled: true
+    permissions:
+      - messaging
+      - notification
+      - user_interaction
+      - ticket_intake
+    deny:
+      - code_generation
+      - code_review
+      - pr_create
+      - pr_merge
+      - commit
+      - investigation
+      - orchestration
+    models: []
+
+  opencode:
+    description: "Auxiliary agent (disabled)"
+    enabled: false
+    permissions:
+      - investigation
+      - code_review
+    deny:
+      - pr_merge
+      - orchestration
+    models: [deepseek-coder]
+
+overrides:
+  - rule: "LOW/MEDIUM bugs can be investigated by gemini-cli"
+    condition:
+      severity: [low, medium]
+      task: investigation
+    allow_agents: [gemini-cli]
+  - rule: "Only claude-code generates code"
+    condition:
+      task: [code_generation, commit, pr_create, pr_merge]
+    allow_agents: [claude-code]
+    enforce: strict
+"""
+
+
+class TestAgentRBAC(unittest.TestCase):
+    """Unit tests for the RBAC engine."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self._roles_path = _write_roles(self._tmp, FULL_ROLES_YAML)
+        self.engine = RBACEngine(roles_path=self._roles_path)
+
+    # --- claude-code permissions ---
+
+    def test_claude_code_code_generation_allowed(self):
+        allowed, reason = self.engine.check_permission("claude-code", "code_generation")
+        self.assertTrue(allowed)
+        self.assertEqual(reason, "granted")
+
+    def test_claude_code_pr_create_allowed(self):
+        allowed, _ = self.engine.check_permission("claude-code", "pr_create")
+        self.assertTrue(allowed)
+
+    def test_claude_code_pr_merge_allowed(self):
+        allowed, _ = self.engine.check_permission("claude-code", "pr_merge")
+        self.assertTrue(allowed)
+
+    def test_claude_code_commit_allowed(self):
+        allowed, _ = self.engine.check_permission("claude-code", "commit")
+        self.assertTrue(allowed)
+
+    # --- gemini-cli explicit denies ---
+
+    def test_gemini_cli_denied_code_generation(self):
+        allowed, reason = self.engine.check_permission("gemini-cli", "code_generation")
+        self.assertFalse(allowed)
+        self.assertIn("explicitly denied", reason)
+
+    def test_gemini_cli_denied_pr_create(self):
+        allowed, _ = self.engine.check_permission("gemini-cli", "pr_create")
+        self.assertFalse(allowed)
+
+    def test_gemini_cli_denied_commit(self):
+        allowed, _ = self.engine.check_permission("gemini-cli", "commit")
+        self.assertFalse(allowed)
+
+    def test_gemini_cli_investigation_allowed(self):
+        allowed, _ = self.engine.check_permission("gemini-cli", "investigation")
+        self.assertTrue(allowed)
+
+    # --- openclaw denies ---
+
+    def test_openclaw_denied_code_generation(self):
+        allowed, reason = self.engine.check_permission("openclaw", "code_generation")
+        self.assertFalse(allowed)
+        self.assertIn("explicitly denied", reason)
+
+    def test_openclaw_denied_investigation(self):
+        allowed, _ = self.engine.check_permission("openclaw", "investigation")
+        self.assertFalse(allowed)
+
+    def test_openclaw_messaging_allowed(self):
+        allowed, _ = self.engine.check_permission("openclaw", "messaging")
+        self.assertTrue(allowed)
+
+    # --- opencode disabled ---
+
+    def test_opencode_disabled_denied_everything(self):
+        allowed, reason = self.engine.check_permission("opencode", "investigation")
+        self.assertFalse(allowed)
+        self.assertIn("disabled", reason)
+
+    def test_opencode_disabled_denied_code_review(self):
+        allowed, reason = self.engine.check_permission("opencode", "code_review")
+        self.assertFalse(allowed)
+        self.assertIn("disabled", reason)
+
+    # --- unknown agent deny-by-default ---
+
+    def test_unknown_agent_denied(self):
+        allowed, reason = self.engine.check_permission("rogue-bot", "code_generation")
+        self.assertFalse(allowed)
+        self.assertIn("Unknown agent", reason)
+
+    # --- override: gemini-cli investigation for low severity ---
+
+    def test_override_gemini_cli_investigation_low_severity(self):
+        """gemini-cli already has investigation in base permissions, but
+        the override also covers it — should be granted either way."""
+        allowed, _ = self.engine.check_permission(
+            "gemini-cli", "investigation", {"severity": "low"}
+        )
+        self.assertTrue(allowed)
+
+    # --- override strict: only claude-code for code_generation ---
+
+    def test_override_strict_blocks_non_claude_code_generation(self):
+        """gemini-cli has code_generation explicitly denied, so it stays denied."""
+        allowed, _ = self.engine.check_permission("gemini-cli", "code_generation")
+        self.assertFalse(allowed)
+
+    # --- enforce raises PermissionDeniedError ---
+
+    def test_enforce_raises_on_denied(self):
+        with self.assertRaises(PermissionDeniedError) as ctx:
+            self.engine.enforce("openclaw", "code_generation")
+        self.assertIn("RBAC", str(ctx.exception))
+
+    def test_enforce_passes_on_allowed(self):
+        # Should not raise
+        self.engine.enforce("claude-code", "code_generation")
+
+    # --- missing roles file => deny-by-default ---
+
+    def test_missing_roles_file_deny_by_default(self):
+        engine = RBACEngine(roles_path=Path("/nonexistent/roles.yaml"))
+        allowed, reason = engine.check_permission("claude-code", "code_generation")
+        self.assertFalse(allowed)
+        self.assertIn("Unknown agent", reason)
+
+    # --- reload picks up changes ---
+
+    def test_reload_picks_up_changes(self):
+        # Initially opencode is disabled
+        allowed, _ = self.engine.check_permission("opencode", "investigation")
+        self.assertFalse(allowed)
+
+        # Update the file to enable opencode
+        data = yaml.safe_load(self._roles_path.read_text())
+        data["roles"]["opencode"]["enabled"] = True
+        self._roles_path.write_text(yaml.dump(data))
+
+        self.engine.reload()
+
+        allowed, reason = self.engine.check_permission("opencode", "investigation")
+        self.assertTrue(allowed)
+        self.assertEqual(reason, "granted")
+
+    # --- list_roles and get_role ---
+
+    def test_list_roles_returns_all(self):
+        roles = self.engine.list_roles()
+        self.assertEqual(set(roles.keys()), {"claude-code", "gemini-cli", "openclaw", "opencode"})
+
+    def test_get_role_returns_none_for_unknown(self):
+        self.assertIsNone(self.engine.get_role("nonexistent"))
+
+    # --- AgentRole unit tests ---
+
+    def test_agent_role_has_permission_deny_wins(self):
+        role = AgentRole("test", {
+            "enabled": True,
+            "permissions": ["code_generation"],
+            "deny": ["code_generation"],
+        })
+        self.assertFalse(role.has_permission("code_generation"))
+
+    def test_agent_role_disabled_denies_all(self):
+        role = AgentRole("test", {
+            "enabled": False,
+            "permissions": ["code_generation"],
+        })
+        self.assertFalse(role.has_permission("code_generation"))
+
+    # --- deny-by-default for unlisted permission ---
+
+    def test_unlisted_permission_denied(self):
+        """A permission not in the list is denied even for claude-code."""
+        allowed, reason = self.engine.check_permission("claude-code", "delete_repo")
+        self.assertFalse(allowed)
+        self.assertIn("does not have permission", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_agent_rbac.py
+++ b/tests/unit/test_agent_rbac.py
@@ -1,5 +1,4 @@
 """Tests for Role-Based Access Control (agent_rbac.py)."""
-import os
 import tempfile
 import textwrap
 import unittest
@@ -8,7 +7,7 @@ from pathlib import Path
 import yaml
 
 from src.swe_team.agent_rbac import (
-    AgentRole,
+    RBACRole,
     PermissionDeniedError,
     RBACEngine,
 )
@@ -110,9 +109,12 @@ class TestAgentRBAC(unittest.TestCase):
     """Unit tests for the RBAC engine."""
 
     def setUp(self):
-        self._tmp = tempfile.mkdtemp()
-        self._roles_path = _write_roles(self._tmp, FULL_ROLES_YAML)
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self._roles_path = _write_roles(self._tmp_dir.name, FULL_ROLES_YAML)
         self.engine = RBACEngine(roles_path=self._roles_path)
+
+    def tearDown(self):
+        self._tmp_dir.cleanup()
 
     # --- claude-code permissions ---
 
@@ -203,6 +205,16 @@ class TestAgentRBAC(unittest.TestCase):
         allowed, _ = self.engine.check_permission("gemini-cli", "code_generation")
         self.assertFalse(allowed)
 
+    def test_override_strict_blocks_openclaw_commit(self):
+        """openclaw is not in allow_agents for the strict override on commit — must be denied."""
+        allowed, reason = self.engine.check_permission("openclaw", "commit")
+        self.assertFalse(allowed)
+
+    def test_override_strict_allows_claude_code_pr_merge(self):
+        """claude-code is in allow_agents for the strict override — must be allowed."""
+        allowed, _ = self.engine.check_permission("claude-code", "pr_merge")
+        self.assertTrue(allowed)
+
     # --- enforce raises PermissionDeniedError ---
 
     def test_enforce_raises_on_denied(self):
@@ -249,18 +261,18 @@ class TestAgentRBAC(unittest.TestCase):
     def test_get_role_returns_none_for_unknown(self):
         self.assertIsNone(self.engine.get_role("nonexistent"))
 
-    # --- AgentRole unit tests ---
+    # --- RBACRole unit tests ---
 
-    def test_agent_role_has_permission_deny_wins(self):
-        role = AgentRole("test", {
+    def test_rbac_role_has_permission_deny_wins(self):
+        role = RBACRole("test", {
             "enabled": True,
             "permissions": ["code_generation"],
             "deny": ["code_generation"],
         })
         self.assertFalse(role.has_permission("code_generation"))
 
-    def test_agent_role_disabled_denies_all(self):
-        role = AgentRole("test", {
+    def test_rbac_role_disabled_denies_all(self):
+        role = RBACRole("test", {
             "enabled": False,
             "permissions": ["code_generation"],
         })
@@ -273,7 +285,3 @@ class TestAgentRBAC(unittest.TestCase):
         allowed, reason = self.engine.check_permission("claude-code", "delete_repo")
         self.assertFalse(allowed)
         self.assertIn("does not have permission", reason)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Closes #9

## Summary
- `config/swe_team/roles.yaml` — 4 agent roles with permissions + deny lists
- `src/swe_team/agent_rbac.py` — RBACEngine, deny-by-default, PermissionDeniedError
- `tests/unit/test_agent_rbac.py` — 25 unit tests

## Test plan
- [x] `python3 -m pytest tests/unit/test_agent_rbac.py -q` — 25 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)