### PR TITLE
fix: post-merge Copilot fixes for model_boundary and scheduler

### DIFF
--- a/src/swe_team/model_boundary.py
+++ b/src/swe_team/model_boundary.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import FrozenSet, Optional
+from typing import FrozenSet
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +34,11 @@ AUTHORIZED_CODE_MODELS: FrozenSet[str] = frozenset({
     "claude-4-opus",
 })
 
-# Pattern to match any Claude model variant
-_CLAUDE_PATTERN = re.compile(r"^(claude|haiku|sonnet|opus)", re.IGNORECASE)
+# Word-boundary pattern for detecting code-generation intent in task strings
+_CODE_TASK_PATTERN = re.compile(
+    r"\b(code|fix|develop|implement|write|generate|patch)\b",
+    re.IGNORECASE,
+)
 
 # Models explicitly BLOCKED — known to have caused incidents
 BLOCKED_MODELS: FrozenSet[str] = frozenset({
@@ -71,8 +74,12 @@ READ_ONLY_TASKS: FrozenSet[str] = frozenset({
 
 
 def is_claude_model(model: str) -> bool:
-    """Check if a model string refers to a Claude model."""
-    return bool(_CLAUDE_PATTERN.match(model.strip()))
+    """Check if a model string refers to a Claude model.
+
+    Returns True only if the model (case-insensitive) is in the exact allowlist.
+    Prefix/substring matches are intentionally NOT accepted to prevent spoofing.
+    """
+    return model.strip().lower() in {m.lower() for m in AUTHORIZED_CODE_MODELS}
 
 
 def validate_model_for_task(model: str, task: str) -> tuple[bool, str]:
@@ -94,8 +101,12 @@ def validate_model_for_task(model: str, task: str) -> tuple[bool, str]:
 
     # Code generation tasks REQUIRE Claude
     task_lower = task.strip().lower()
-    if task_lower in CODE_GENERATION_TASKS or "code" in task_lower or "fix" in task_lower or "develop" in task_lower:
-        if not is_claude_model(model):
+    is_code_task = (
+        task_lower in CODE_GENERATION_TASKS
+        or bool(_CODE_TASK_PATTERN.search(task_lower))
+    )
+    if is_code_task:
+        if model_lower not in {m.lower() for m in AUTHORIZED_CODE_MODELS}:
             logger.critical(
                 "SEC-68 MODEL BOUNDARY VIOLATION: non-Claude model '%s' "
                 "attempted for code generation task '%s' — DENIED",

--- a/src/swe_team/scheduler.py
+++ b/src/swe_team/scheduler.py
@@ -11,6 +11,7 @@ Supports:
 - Pluggable executor (Claude CLI, A2A agents, shell commands)
 - Retry with exponential backoff
 - Concurrency limiting via ThreadPoolExecutor
+- Run history tracking (JSONL-backed)
 """
 from __future__ import annotations
 
@@ -69,7 +70,11 @@ class TimeWindow:
         dt = dt or datetime.now(timezone.utc)
         if not self.is_peak(dt):
             return dt
-        candidate = dt.replace(hour=self.peak_end_hour, minute=0, second=0, microsecond=0)
+        # Fix #1: handle peak_end_hour >= 24 (dt.replace(hour=24) raises ValueError)
+        if self.peak_end_hour >= 24:
+            candidate = (dt + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        else:
+            candidate = dt.replace(hour=self.peak_end_hour, minute=0, second=0, microsecond=0)
         if candidate <= dt:
             candidate += timedelta(days=1)
         # Skip weekends if peak_days is weekdays only
@@ -133,22 +138,71 @@ class ScheduledJob:
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
 
+@dataclass
+class RunRecord:
+    """A single execution record for a scheduled job."""
+    job_id: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    status: str = "unknown"  # "success" | "failed" | "error"
+    duration_seconds: float = 0.0
+    error: Optional[str] = None
+    attempt_count: int = 1
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RunRecord":
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
 def parse_cron_field(field_str: str, min_val: int, max_val: int) -> List[int]:
-    """Parse a single cron field into a list of matching integers."""
+    """Parse a single cron field into a list of matching integers.
+
+    Fix #2: validate step != 0, clamp range bounds, validate non-integer tokens.
+    """
     values = set()
     for part in field_str.split(","):
         part = part.strip()
         if part == "*":
             values.update(range(min_val, max_val + 1))
         elif part.startswith("*/"):
-            step = int(part[2:])
+            step_str = part[2:]
+            if not step_str.isdigit():
+                raise ValueError(f"Invalid cron step: {part!r}")
+            step = int(step_str)
+            if step == 0:
+                raise ValueError(f"Cron step cannot be zero: {part!r}")
             values.update(range(min_val, max_val + 1, step))
         elif "-" in part:
-            start, end = part.split("-", 1)
-            values.update(range(int(start), int(end) + 1))
+            raw_start, raw_end = part.split("-", 1)
+            if not raw_start.strip().isdigit() or not raw_end.strip().isdigit():
+                raise ValueError(f"Invalid cron range: {part!r}")
+            start = max(min_val, int(raw_start))
+            end = min(max_val, int(raw_end))
+            if start <= end:
+                values.update(range(start, end + 1))
         else:
+            if not part.isdigit():
+                raise ValueError(f"Invalid cron token: {part!r}")
             values.add(int(part))
     return sorted(v for v in values if min_val <= v <= max_val)
+
+
+def _translate_dow(cron_dow_values: List[int]) -> List[int]:
+    """Translate cron DOW values to Python weekday() values.
+
+    Fix #3: standard cron uses Sun=0 (or 7), Mon=1..Sat=6.
+    Python datetime.weekday() uses Mon=0..Sun=6.
+    Mapping: cron 0 or 7 -> Python 6 (Sunday), cron N (1-6) -> Python N-1.
+    """
+    python_days = set()
+    for d in cron_dow_values:
+        if d == 0 or d == 7:
+            python_days.add(6)  # Sunday
+        else:
+            python_days.add(d - 1)  # Mon=1->0, Tue=2->1, ..., Sat=6->5
+    return sorted(python_days)
 
 
 def cron_matches(expression: str, dt: datetime) -> bool:
@@ -157,12 +211,14 @@ def cron_matches(expression: str, dt: datetime) -> bool:
     if len(fields) != 5:
         return False
     minute, hour, dom, month, dow = fields
+    # Fix #3: translate DOW from cron convention to Python weekday convention
+    dow_values = _translate_dow(parse_cron_field(dow, 0, 7))
     return (
         dt.minute in parse_cron_field(minute, 0, 59)
         and dt.hour in parse_cron_field(hour, 0, 23)
         and dt.day in parse_cron_field(dom, 1, 31)
         and dt.month in parse_cron_field(month, 1, 12)
-        and dt.weekday() in parse_cron_field(dow, 0, 6)
+        and dt.weekday() in dow_values
     )
 
 
@@ -174,7 +230,72 @@ def next_cron_match(expression: str, after: Optional[datetime] = None) -> dateti
         if cron_matches(expression, dt):
             return dt
         dt += timedelta(minutes=1)
-    return dt  # fallback
+    raise ValueError(f"No cron match found within 48h for expression: {expression!r}")
+
+
+class RunHistoryStore:
+    """JSONL file-backed run history persistence."""
+
+    def __init__(self, path: Path, max_records_per_job: int = 50):
+        if isinstance(path, str):
+            path = Path(path)
+        self._path = path
+        self._max_per_job = max_records_per_job
+        self._lock = threading.Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, record: RunRecord) -> None:
+        """Append a run record to the JSONL file."""
+        with self._lock:
+            with open(self._path, "a") as f:
+                f.write(json.dumps(record.to_dict(), default=str) + "\n")
+
+    def get_history(self, job_id: Optional[str] = None, limit: int = 20) -> List[RunRecord]:
+        """Load run history, optionally filtered by job_id."""
+        with self._lock:
+            if not self._path.exists():
+                return []
+            records: List[RunRecord] = []
+            try:
+                for line in self._path.read_text().strip().split("\n"):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                        rec = RunRecord.from_dict(data)
+                        if job_id is None or rec.job_id == job_id:
+                            records.append(rec)
+                    except (json.JSONDecodeError, KeyError):
+                        continue
+            except Exception:
+                logger.warning("Error reading run history from %s", self._path)
+                return []
+            records.reverse()
+            return records[:limit]
+
+    def prune(self, job_id: str) -> None:
+        """Keep only the last max_records_per_job entries for a given job."""
+        with self._lock:
+            if not self._path.exists():
+                return
+            job_lines: List[str] = []
+            other_lines: List[str] = []
+            for line in self._path.read_text().strip().split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                    if data.get("job_id") == job_id:
+                        job_lines.append(line)
+                    else:
+                        other_lines.append(line)
+                except json.JSONDecodeError:
+                    other_lines.append(line)
+            kept = job_lines[-self._max_per_job:]
+            all_lines = other_lines + kept
+            self._path.write_text("\n".join(all_lines) + "\n" if all_lines else "")
 
 
 class JobStore:
@@ -187,32 +308,57 @@ class JobStore:
         self._lock = threading.Lock()
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
+    def _load_all_locked(self) -> List[ScheduledJob]:
+        """Load all jobs; caller must hold _lock."""
+        if not self._path.exists():
+            return []
+        try:
+            data = json.loads(self._path.read_text())
+            jobs = []
+            # Fix #5: skip corrupt individual entries instead of crashing
+            for j in data:
+                try:
+                    jobs.append(ScheduledJob.from_dict(j))
+                except (ValueError, TypeError, KeyError) as exc:
+                    logger.warning("Skipping corrupt job entry: %s", exc)
+            return jobs
+        except (json.JSONDecodeError, KeyError):
+            logger.warning("Corrupt job store at %s — returning empty", self._path)
+            return []
+
     def load_all(self) -> List[ScheduledJob]:
         with self._lock:
-            if not self._path.exists():
-                return []
-            try:
-                data = json.loads(self._path.read_text())
-                return [ScheduledJob.from_dict(j) for j in data]
-            except (json.JSONDecodeError, KeyError):
-                logger.warning("Corrupt job store at %s — returning empty", self._path)
-                return []
+            return self._load_all_locked()
 
     def save_all(self, jobs: List[ScheduledJob]) -> None:
         with self._lock:
             tmp = self._path.with_suffix(".tmp")
             tmp.write_text(json.dumps([j.to_dict() for j in jobs], indent=2, default=str))
-            tmp.rename(self._path)
+            # Fix #6: use replace() for atomic cross-platform writes
+            tmp.replace(self._path)
 
     def upsert(self, job: ScheduledJob) -> None:
+        # Fix #7: hold _lock across the full read-modify-write in a single block
+        with self._lock:
+            jobs = self._load_all_locked()
+            for i, j in enumerate(jobs):
+                if j.job_id == job.job_id:
+                    jobs[i] = job
+                    break
+            else:
+                jobs.append(job)
+            tmp = self._path.with_suffix(".tmp")
+            tmp.write_text(json.dumps([j.to_dict() for j in jobs], indent=2, default=str))
+            tmp.replace(self._path)
+
+    def delete_job(self, job_id: str) -> bool:
+        """Permanently remove a job from the store. Returns True if found and deleted."""
         jobs = self.load_all()
-        for i, j in enumerate(jobs):
-            if j.job_id == job.job_id:
-                jobs[i] = job
-                self.save_all(jobs)
-                return
-        jobs.append(job)
-        self.save_all(jobs)
+        filtered = [j for j in jobs if j.job_id != job_id]
+        if len(filtered) == len(jobs):
+            return False
+        self.save_all(filtered)
+        return True
 
 
 class JobScheduler:
@@ -242,13 +388,31 @@ class JobScheduler:
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._running_jobs: Dict[str, bool] = {}
+        # Fix #9: dedicated lock for _running_jobs dict
+        self._running_lock = threading.Lock()
+        # Run history store (sibling to the job store file)
+        self._history = RunHistoryStore(
+            self._store._path.parent / "run_history.jsonl"
+        )
 
     # --- CRUD ---
 
     def add_job(self, job: ScheduledJob) -> ScheduledJob:
-        if job.schedule_type == ScheduleType.CRON and job.cron_expression:
-            job.next_run = next_cron_match(job.cron_expression).isoformat()
-        elif job.schedule_type == ScheduleType.INTERVAL and job.interval_minutes > 0:
+        # Fix #8: validate schedule parameters
+        if job.schedule_type == ScheduleType.CRON:
+            if not job.cron_expression:
+                raise ValueError(f"Cron job {job.name!r} must have a non-empty cron_expression")
+            try:
+                job.next_run = next_cron_match(job.cron_expression).isoformat()
+            except ValueError as exc:
+                job.status = JobStatus.PENDING
+                job.last_error = str(exc)
+                self._store.upsert(job)
+                logger.warning("add_job: cron expression error for %s: %s", job.name, exc)
+                return job
+        elif job.schedule_type == ScheduleType.INTERVAL:
+            if job.interval_minutes <= 0:
+                raise ValueError(f"Interval job {job.name!r} must have interval_minutes > 0")
             job.next_run = (datetime.now(timezone.utc) + timedelta(minutes=job.interval_minutes)).isoformat()
         job.status = JobStatus.SCHEDULED
         self._store.upsert(job)
@@ -299,6 +463,20 @@ class JobScheduler:
         self._pool.submit(self._execute_job, job)
         return job
 
+    def delete_job(self, job_id: str) -> bool:
+        """Permanently remove a job from the store and running state."""
+        # Fix #9: protect _running_jobs
+        with self._running_lock:
+            self._running_jobs.pop(job_id, None)
+        deleted = self._store.delete_job(job_id)
+        if deleted:
+            logger.info("Job deleted: %s", job_id)
+        return deleted
+
+    def get_run_history(self, job_id: Optional[str] = None, limit: int = 20) -> List[RunRecord]:
+        """Get run history records, optionally filtered by job_id."""
+        return self._history.get_history(job_id=job_id, limit=limit)
+
     # --- Scheduling logic ---
 
     def should_run(self, job: ScheduledJob) -> tuple[bool, str]:
@@ -306,14 +484,19 @@ class JobScheduler:
         if not job.enabled or job.status not in (JobStatus.SCHEDULED, JobStatus.PENDING):
             return False, "not enabled or not scheduled"
 
-        if job.job_id in self._running_jobs:
-            return False, "already running"
+        # Fix #9: protect _running_jobs with lock
+        with self._running_lock:
+            if job.job_id in self._running_jobs:
+                return False, "already running"
 
         now = datetime.now(timezone.utc)
 
         # Check if it's time
         if job.next_run:
             next_dt = datetime.fromisoformat(job.next_run)
+            # Fix #10: normalize naive datetimes to UTC
+            if next_dt.tzinfo is None:
+                next_dt = next_dt.replace(tzinfo=timezone.utc)
             if now < next_dt:
                 return False, f"not due until {job.next_run}"
 
@@ -340,21 +523,31 @@ class JobScheduler:
             job.status = JobStatus.COMPLETED
             job.next_run = None
         elif job.schedule_type == ScheduleType.CRON:
-            job.next_run = next_cron_match(job.cron_expression, after=now).isoformat()
+            try:
+                job.next_run = next_cron_match(job.cron_expression, after=now).isoformat()
+            except ValueError as exc:
+                logger.warning("_advance_schedule: cron error for %s: %s", job.name, exc)
+                job.status = JobStatus.PENDING
+                job.last_error = str(exc)
+                return
             job.status = JobStatus.SCHEDULED
         elif job.schedule_type == ScheduleType.INTERVAL:
             job.next_run = (now + timedelta(minutes=job.interval_minutes)).isoformat()
             job.status = JobStatus.SCHEDULED
 
     def _execute_job(self, job: ScheduledJob) -> None:
-        """Execute a single job with retry logic."""
-        self._running_jobs[job.job_id] = True
+        """Execute a single job with retry logic. Records run history."""
+        # Fix #9: protect _running_jobs
+        with self._running_lock:
+            self._running_jobs[job.job_id] = True
         job.status = JobStatus.RUNNING
-        job.last_run = datetime.now(timezone.utc).isoformat()
+        start_time = datetime.now(timezone.utc)
+        job.last_run = start_time.isoformat()
         self._store.upsert(job)
 
         attempt = 0
         success = False
+        last_error_msg: Optional[str] = None
         while attempt <= job.max_retries:
             try:
                 self._executor(job)
@@ -362,11 +555,15 @@ class JobScheduler:
                 break
             except Exception as exc:
                 attempt += 1
-                job.last_error = f"Attempt {attempt}: {str(exc)[:200]}"
+                last_error_msg = f"Attempt {attempt}: {str(exc)[:200]}"
+                job.last_error = last_error_msg
                 logger.warning("Job %s attempt %d failed: %s", job.job_id, attempt, exc)
                 if attempt <= job.max_retries:
                     backoff = job.retry_backoff_seconds * (2 ** (attempt - 1))
                     self._stop_event.wait(min(backoff, 300))
+
+        end_time = datetime.now(timezone.utc)
+        duration = (end_time - start_time).total_seconds()
 
         job.run_count += 1
         if success:
@@ -377,8 +574,21 @@ class JobScheduler:
             job.status = JobStatus.FAILED
             logger.error("Job %s failed after %d retries", job.name, job.max_retries + 1)
 
+        # Record run history
+        record = RunRecord(
+            job_id=job.job_id,
+            timestamp=start_time.isoformat(),
+            status="success" if success else "failed",
+            duration_seconds=round(duration, 2),
+            error=last_error_msg if not success else None,
+            attempt_count=attempt + (1 if success else 0),
+        )
+        self._history.append(record)
+
         self._store.upsert(job)
-        self._running_jobs.pop(job.job_id, None)
+        # Fix #9: protect _running_jobs
+        with self._running_lock:
+            self._running_jobs.pop(job.job_id, None)
 
     def _default_executor(self, job: ScheduledJob) -> None:
         logger.info("DEFAULT EXECUTOR (stub): job=%s instructions=%s", job.name, job.instructions[:100])

--- a/tests/unit/test_model_boundary.py
+++ b/tests/unit/test_model_boundary.py
@@ -6,140 +6,199 @@ Validates that:
 - kimi-k2.5 and other blocked models are always rejected
 - Read-only tasks (investigate, review) allow non-Claude models
 - Unknown tasks default to Claude-only (fail-secure)
+- Spoofed names (haiku-openai, sonnet-local) are rejected
 """
 from __future__ import annotations
 
-import unittest
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src.swe_team.model_boundary import (
-    is_claude_model,
-    validate_model_for_task,
-    enforce_code_generation_boundary,
     AUTHORIZED_CODE_MODELS,
     BLOCKED_MODELS,
+    enforce_code_generation_boundary,
+    is_claude_model,
+    validate_model_for_task,
 )
 
 
-class TestIsClaudeModel(unittest.TestCase):
-    """Test Claude model identification."""
+# ---------------------------------------------------------------------------
+# is_claude_model — exact allowlist checks
+# ---------------------------------------------------------------------------
 
-    def test_haiku_is_claude(self):
-        assert is_claude_model("haiku")
-
-    def test_sonnet_is_claude(self):
-        assert is_claude_model("sonnet")
-
-    def test_opus_is_claude(self):
-        assert is_claude_model("opus")
-
-    def test_claude_3_sonnet_is_claude(self):
-        assert is_claude_model("claude-3-sonnet")
-
-    def test_claude_prefix_is_claude(self):
-        assert is_claude_model("claude-4-opus")
-
-    def test_kimi_is_not_claude(self):
-        assert not is_claude_model("kimi-k2.5")
-
-    def test_gemini_is_not_claude(self):
-        assert not is_claude_model("gemini-2.5-flash")
-
-    def test_gpt_is_not_claude(self):
-        assert not is_claude_model("gpt-4o")
-
-    def test_empty_string(self):
-        assert not is_claude_model("")
-
-    def test_case_insensitive(self):
-        assert is_claude_model("Claude-3-Sonnet")
-        assert is_claude_model("HAIKU")
+def test_haiku_is_claude():
+    assert is_claude_model("haiku")
 
 
-class TestValidateModelForTask(unittest.TestCase):
-    """Test model-task validation matrix."""
-
-    # Code generation tasks — Claude only
-    def test_claude_for_develop_allowed(self):
-        allowed, _ = validate_model_for_task("sonnet", "develop")
-        assert allowed
-
-    def test_claude_for_fix_allowed(self):
-        allowed, _ = validate_model_for_task("haiku", "fix")
-        assert allowed
-
-    def test_gemini_for_develop_blocked(self):
-        allowed, reason = validate_model_for_task("gemini-flash", "develop")
-        assert not allowed
-        assert "not authorized" in reason.lower()
-
-    def test_kimi_for_develop_blocked(self):
-        allowed, reason = validate_model_for_task("kimi-k2.5", "develop")
-        assert not allowed
-        assert "blocked" in reason.lower() or "permanently" in reason.lower()
-
-    def test_kimi_for_investigate_also_blocked(self):
-        """kimi is permanently blocked for ALL tasks."""
-        allowed, reason = validate_model_for_task("kimi-k2.5:cloud", "investigate")
-        assert not allowed
-
-    # Read-only tasks — any non-blocked model OK
-    def test_gemini_for_investigate_allowed(self):
-        allowed, _ = validate_model_for_task("gemini-flash", "investigate")
-        assert allowed
-
-    def test_gemini_for_review_allowed(self):
-        allowed, _ = validate_model_for_task("gemini-flash", "review")
-        assert allowed
-
-    def test_gemini_for_search_allowed(self):
-        allowed, _ = validate_model_for_task("gemini-flash", "search")
-        assert allowed
-
-    # Unknown tasks — fail-secure (Claude only)
-    def test_unknown_task_claude_allowed(self):
-        allowed, _ = validate_model_for_task("sonnet", "some_new_task")
-        assert allowed
-
-    def test_unknown_task_gemini_blocked(self):
-        allowed, _ = validate_model_for_task("gemini-flash", "some_new_task")
-        assert not allowed
+def test_sonnet_is_claude():
+    assert is_claude_model("sonnet")
 
 
-class TestEnforceCodeGenerationBoundary(unittest.TestCase):
-    """Test the enforcement gate function."""
-
-    def test_claude_passes(self):
-        result = enforce_code_generation_boundary("sonnet", task="develop")
-        assert result == "sonnet"
-
-    def test_kimi_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            enforce_code_generation_boundary("kimi-k2.5", task="develop")
-        assert "MODEL BOUNDARY VIOLATION" in str(ctx.exception)
-
-    def test_gemini_for_code_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            enforce_code_generation_boundary("gemini-flash", task="fix")
-        assert "MODEL BOUNDARY VIOLATION" in str(ctx.exception)
-
-    def test_blocked_model_always_raises(self):
-        for model in BLOCKED_MODELS:
-            with self.assertRaises(ValueError, msg=f"{model} should be blocked"):
-                enforce_code_generation_boundary(model, task="investigate")
+def test_opus_is_claude():
+    assert is_claude_model("opus")
 
 
-class TestBlockedModels(unittest.TestCase):
-    """Ensure all known-bad models are in the blocklist."""
-
-    def test_kimi_variants_blocked(self):
-        for variant in ["kimi", "kimi-k2", "kimi-k2.5", "kimi-k2.5:cloud", "moonshot"]:
-            allowed, _ = validate_model_for_task(variant, "develop")
-            assert not allowed, f"{variant} should be blocked"
+def test_claude_3_sonnet_is_claude():
+    assert is_claude_model("claude-3-sonnet")
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_claude_prefix_is_claude():
+    assert is_claude_model("claude-4-opus")
+
+
+def test_kimi_is_not_claude():
+    assert not is_claude_model("kimi-k2.5")
+
+
+def test_gemini_is_not_claude():
+    assert not is_claude_model("gemini-2.5-flash")
+
+
+def test_gpt_is_not_claude():
+    assert not is_claude_model("gpt-4o")
+
+
+def test_empty_string():
+    assert not is_claude_model("")
+
+
+def test_case_insensitive():
+    assert is_claude_model("Claude-3-Sonnet")
+    assert is_claude_model("HAIKU")
+
+
+# Spoofed names must NOT pass — they are not in AUTHORIZED_CODE_MODELS
+def test_haiku_openai_is_not_claude():
+    assert not is_claude_model("haiku-openai")
+
+
+def test_sonnet_local_is_not_claude():
+    assert not is_claude_model("sonnet-local")
+
+
+def test_claude_fake_is_not_claude():
+    assert not is_claude_model("claude-fake")
+
+
+def test_all_authorized_models_pass():
+    """Every entry in AUTHORIZED_CODE_MODELS must pass is_claude_model."""
+    for m in AUTHORIZED_CODE_MODELS:
+        assert is_claude_model(m), f"Expected {m!r} to be recognized as a Claude model"
+
+
+# ---------------------------------------------------------------------------
+# validate_model_for_task
+# ---------------------------------------------------------------------------
+
+def test_claude_for_develop_allowed():
+    allowed, _ = validate_model_for_task("sonnet", "develop")
+    assert allowed
+
+
+def test_claude_for_fix_allowed():
+    allowed, _ = validate_model_for_task("haiku", "fix")
+    assert allowed
+
+
+def test_gemini_for_develop_blocked():
+    allowed, reason = validate_model_for_task("gemini-flash", "develop")
+    assert not allowed
+    assert "not authorized" in reason.lower()
+
+
+def test_kimi_for_develop_blocked():
+    allowed, reason = validate_model_for_task("kimi-k2.5", "develop")
+    assert not allowed
+    assert "blocked" in reason.lower() or "permanently" in reason.lower()
+
+
+def test_kimi_for_investigate_also_blocked():
+    """kimi is permanently blocked for ALL tasks."""
+    allowed, _ = validate_model_for_task("kimi-k2.5:cloud", "investigate")
+    assert not allowed
+
+
+def test_gemini_for_investigate_allowed():
+    allowed, _ = validate_model_for_task("gemini-flash", "investigate")
+    assert allowed
+
+
+def test_gemini_for_review_allowed():
+    allowed, _ = validate_model_for_task("gemini-flash", "review")
+    assert allowed
+
+
+def test_gemini_for_search_allowed():
+    allowed, _ = validate_model_for_task("gemini-flash", "search")
+    assert allowed
+
+
+def test_unknown_task_claude_allowed():
+    allowed, _ = validate_model_for_task("sonnet", "some_new_task")
+    assert allowed
+
+
+def test_unknown_task_gemini_blocked():
+    allowed, _ = validate_model_for_task("gemini-flash", "some_new_task")
+    assert not allowed
+
+
+def test_code_word_boundary_triggers_gate():
+    """Task string 'write code' must trigger the gate for non-Claude models."""
+    allowed, reason = validate_model_for_task("gemini-flash", "write code")
+    assert not allowed
+    assert "not authorized" in reason.lower()
+
+
+def test_prefix_not_misclassified_as_code_gen():
+    """'prefix' does not contain a whole code-gen keyword — should hit fail-secure deny."""
+    allowed, reason = validate_model_for_task("gemini-flash", "prefix")
+    # Falls through to unknown-task fail-secure, NOT a code-gen boundary violation
+    assert not allowed
+    assert "not authorized" not in reason.lower()
+
+
+def test_decode_not_misclassified_as_code_gen():
+    """'decode' does not contain a whole code-gen keyword — should hit fail-secure deny."""
+    allowed, reason = validate_model_for_task("gemini-flash", "decode")
+    assert not allowed
+    assert "not authorized" not in reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# enforce_code_generation_boundary
+# ---------------------------------------------------------------------------
+
+def test_claude_passes():
+    result = enforce_code_generation_boundary("sonnet", task="develop")
+    assert result == "sonnet"
+
+
+def test_kimi_raises():
+    with pytest.raises(ValueError, match="MODEL BOUNDARY VIOLATION"):
+        enforce_code_generation_boundary("kimi-k2.5", task="develop")
+
+
+def test_gemini_for_code_raises():
+    with pytest.raises(ValueError, match="MODEL BOUNDARY VIOLATION"):
+        enforce_code_generation_boundary("gemini-flash", task="fix")
+
+
+def test_blocked_model_always_raises():
+    for model in BLOCKED_MODELS:
+        with pytest.raises(ValueError, match="MODEL BOUNDARY VIOLATION"):
+            enforce_code_generation_boundary(model, task="investigate")
+
+
+# ---------------------------------------------------------------------------
+# Blocked model variants
+# ---------------------------------------------------------------------------
+
+def test_kimi_variants_blocked():
+    for variant in ["kimi", "kimi-k2", "kimi-k2.5", "kimi-k2.5:cloud", "moonshot"]:
+        allowed, _ = validate_model_for_task(variant, "develop")
+        assert not allowed, f"{variant} should be blocked"

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -63,13 +63,26 @@ class TestParseCronField(unittest.TestCase):
         # */2 on months (1-12)
         self.assertEqual(parse_cron_field("*/2", 1, 12), [1, 3, 5, 7, 9, 11])
 
+    def test_step_zero_raises(self):
+        with self.assertRaises(ValueError):
+            parse_cron_field("*/0", 0, 59)
+
+    def test_non_integer_raises(self):
+        with self.assertRaises(ValueError):
+            parse_cron_field("abc", 0, 59)
+
+    def test_range_clamped_to_bounds(self):
+        # Range 0-30 clamped to [1, 12] for months -> [1..12]
+        result = parse_cron_field("0-30", 1, 12)
+        self.assertEqual(result, list(range(1, 13)))
+
 
 # ---------------------------------------------------------------------------
 # 2. cron_matches
 # ---------------------------------------------------------------------------
 class TestCronMatches(unittest.TestCase):
     def _dt(self, minute=0, hour=0, day=1, month=1, year=2026):
-        # weekday: Jan 1, 2026 = Thursday (3)
+        # weekday: Jan 1, 2026 = Thursday (Python weekday 3)
         return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
 
     def test_every_minute(self):
@@ -84,9 +97,23 @@ class TestCronMatches(unittest.TestCase):
         self.assertFalse(cron_matches("0 12 * * *", self._dt(minute=0, hour=11)))
 
     def test_day_of_week(self):
-        # Jan 1, 2026 = Thursday = weekday 3
-        self.assertTrue(cron_matches("0 0 * * 3", self._dt()))
-        self.assertFalse(cron_matches("0 0 * * 1", self._dt()))
+        # Jan 1, 2026 = Thursday = Python weekday 3 = cron DOW 4
+        self.assertTrue(cron_matches("0 0 * * 4", self._dt()))
+        self.assertFalse(cron_matches("0 0 * * 2", self._dt()))
+
+    def test_day_of_week_sunday(self):
+        # Jan 4, 2026 = Sunday = Python weekday 6
+        # In cron convention Sunday = cron 0 (or 7)
+        dt_sun = datetime(2026, 1, 4, 0, 0, tzinfo=timezone.utc)
+        self.assertTrue(cron_matches("0 0 * * 0", dt_sun))
+        self.assertTrue(cron_matches("0 0 * * 7", dt_sun))
+        self.assertFalse(cron_matches("0 0 * * 1", dt_sun))
+
+    def test_day_of_week_monday(self):
+        # Jan 5, 2026 = Monday = Python weekday 0 = cron DOW 1
+        dt_mon = datetime(2026, 1, 5, 0, 0, tzinfo=timezone.utc)
+        self.assertTrue(cron_matches("0 0 * * 1", dt_mon))
+        self.assertFalse(cron_matches("0 0 * * 0", dt_mon))
 
     def test_day_of_month(self):
         self.assertTrue(cron_matches("0 0 1 * *", self._dt(day=1)))
@@ -142,6 +169,11 @@ class TestNextCronMatch(unittest.TestCase):
         result = next_cron_match("*/5 * * * *", after=base)
         self.assertTrue(result - base < timedelta(hours=48))
 
+    def test_no_match_raises_value_error(self):
+        # Feb 30 does not exist -- no match within 48h
+        with self.assertRaises(ValueError):
+            next_cron_match("0 0 30 2 *")
+
 
 # ---------------------------------------------------------------------------
 # 4. TimeWindow
@@ -191,6 +223,15 @@ class TestTimeWindow(unittest.TestCase):
         dt_off = datetime(2026, 1, 7, 10, 0, tzinfo=timezone.utc)   # Wednesday
         self.assertTrue(tw.is_peak(dt_peak))
         self.assertFalse(tw.is_peak(dt_off))
+
+    def test_next_off_peak_peak_end_hour_24(self):
+        # peak_end_hour=24 must not call dt.replace(hour=24) -- rolls to midnight next day
+        tw = TimeWindow(peak_start_hour=0, peak_end_hour=24, peak_days=list(range(7)))
+        dt = datetime(2026, 1, 7, 15, 0, tzinfo=timezone.utc)
+        result = tw.next_off_peak(dt)
+        self.assertEqual(result.hour, 0)
+        self.assertEqual(result.minute, 0)
+        self.assertEqual(result.day, 8)
 
 
 # ---------------------------------------------------------------------------
@@ -303,16 +344,34 @@ class TestJobStore(unittest.TestCase):
             store.save_all([])
             self.assertEqual(store.load_all(), [])
 
+    def test_corrupt_entry_skipped(self):
+        """Individual corrupt entries are skipped; valid ones survive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "jobs.json"
+            data = [
+                {"job_id": "good", "name": "good job"},
+                {"job_id": "bad", "status": "not_a_real_status"},
+            ]
+            p.write_text(json.dumps(data))
+            store = JobStore(p)
+            loaded = store.load_all()
+            self.assertEqual(len(loaded), 1)
+            self.assertEqual(loaded[0].job_id, "good")
+
 
 # ---------------------------------------------------------------------------
 # 7. JobScheduler.should_run
 # ---------------------------------------------------------------------------
 class TestShouldRun(unittest.TestCase):
+    def setUp(self):
+        # Fix #11: keep TemporaryDirectory alive on the instance
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
     def _make_scheduler(self, time_window=None, quota_checker=None):
-        with tempfile.TemporaryDirectory() as tmp:
-            pass
-        # We use a store but won't persist
-        store = JobStore(Path(tmp) / "jobs.json")
+        store = JobStore(Path(self._tmpdir.name) / "jobs.json")
         return JobScheduler(store=store, time_window=time_window, quota_checker=quota_checker)
 
     def _make_job(self, **kw):
@@ -331,10 +390,7 @@ class TestShouldRun(unittest.TestCase):
 
     def test_runs_when_due(self):
         sched = self._make_scheduler()
-        job = self._make_job(
-            next_run=(datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat(),
-            respect_peak_hours=False,
-        )
+        job = self._make_job(next_run=(datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat())
         ok, reason = sched.should_run(job)
         self.assertTrue(ok)
         self.assertEqual(reason, "ready")
@@ -359,8 +415,8 @@ class TestShouldRun(unittest.TestCase):
         self.assertFalse(ok)
 
     def test_defers_normal_during_peak(self):
-        # Create a time window where it's always peak (0 <= hour < 24)
-        tw = TimeWindow(peak_start_hour=0, peak_end_hour=24, peak_days=list(range(7)))
+        # peak_end_hour=23: hours 0..22 are peak (real hour is always < 23)
+        tw = TimeWindow(peak_start_hour=0, peak_end_hour=23, peak_days=list(range(7)))
         sched = self._make_scheduler(time_window=tw)
         job = self._make_job(
             priority=JobPriority.NORMAL,
@@ -371,7 +427,7 @@ class TestShouldRun(unittest.TestCase):
         self.assertIn("peak", reason)
 
     def test_defers_low_during_peak(self):
-        tw = TimeWindow(peak_start_hour=0, peak_end_hour=24, peak_days=list(range(7)))
+        tw = TimeWindow(peak_start_hour=0, peak_end_hour=23, peak_days=list(range(7)))
         sched = self._make_scheduler(time_window=tw)
         job = self._make_job(
             priority=JobPriority.LOW,
@@ -382,7 +438,7 @@ class TestShouldRun(unittest.TestCase):
         self.assertIn("peak", reason)
 
     def test_critical_ignores_peak(self):
-        tw = TimeWindow(peak_start_hour=0, peak_end_hour=24, peak_days=list(range(7)))
+        tw = TimeWindow(peak_start_hour=0, peak_end_hour=23, peak_days=list(range(7)))
         sched = self._make_scheduler(time_window=tw)
         job = self._make_job(
             priority=JobPriority.CRITICAL,
@@ -437,19 +493,34 @@ class TestShouldRun(unittest.TestCase):
         job = self._make_job(
             next_run=(datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat(),
         )
-        sched._running_jobs[job.job_id] = True
+        with sched._running_lock:
+            sched._running_jobs[job.job_id] = True
         ok, reason = sched.should_run(job)
         self.assertFalse(ok)
         self.assertIn("already running", reason)
+
+    def test_naive_next_run_normalized_to_utc(self):
+        sched = self._make_scheduler()
+        naive_past = (datetime.now(timezone.utc) - timedelta(minutes=5)).replace(tzinfo=None)
+        job = self._make_job(next_run=naive_past.isoformat())
+        ok, reason = sched.should_run(job)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "ready")
 
 
 # ---------------------------------------------------------------------------
 # 8. JobScheduler._advance_schedule
 # ---------------------------------------------------------------------------
 class TestAdvanceSchedule(unittest.TestCase):
+    def setUp(self):
+        # Fix #11: keep TemporaryDirectory alive on the instance
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
     def _make_scheduler(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            store = JobStore(Path(tmp) / "jobs.json")
+        store = JobStore(Path(self._tmpdir.name) / "jobs.json")
         return JobScheduler(store=store)
 
     def test_once_completed(self):
@@ -614,11 +685,48 @@ class TestAddJob(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             store = JobStore(Path(tmp) / "jobs.json")
             sched = JobScheduler(store=store)
-            job = ScheduledJob(job_id="persist1", name="persisted")
+            job = ScheduledJob(job_id="persist1", name="persisted",
+                               schedule_type=ScheduleType.ONCE)
             sched.add_job(job)
             loaded = store.load_all()
             self.assertEqual(len(loaded), 1)
             self.assertEqual(loaded[0].job_id, "persist1")
+
+    def test_add_cron_job_empty_expression_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(Path(tmp) / "jobs.json")
+            sched = JobScheduler(store=store)
+            job = ScheduledJob(
+                job_id="bad-cron",
+                schedule_type=ScheduleType.CRON,
+                cron_expression="",
+            )
+            with self.assertRaises(ValueError):
+                sched.add_job(job)
+
+    def test_add_interval_job_zero_minutes_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(Path(tmp) / "jobs.json")
+            sched = JobScheduler(store=store)
+            job = ScheduledJob(
+                job_id="bad-interval",
+                schedule_type=ScheduleType.INTERVAL,
+                interval_minutes=0,
+            )
+            with self.assertRaises(ValueError):
+                sched.add_job(job)
+
+    def test_add_interval_job_negative_minutes_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(Path(tmp) / "jobs.json")
+            sched = JobScheduler(store=store)
+            job = ScheduledJob(
+                job_id="bad-interval-neg",
+                schedule_type=ScheduleType.INTERVAL,
+                interval_minutes=-5,
+            )
+            with self.assertRaises(ValueError):
+                sched.add_job(job)
 
 
 # ---------------------------------------------------------------------------
@@ -629,7 +737,8 @@ class TestCRUD(unittest.TestCase):
         tmp = tempfile.mkdtemp()
         store = JobStore(Path(tmp) / "jobs.json")
         sched = JobScheduler(store=store)
-        job = ScheduledJob(job_id="crud1", name="crud test")
+        job = ScheduledJob(job_id="crud1", name="crud test",
+                           schedule_type=ScheduleType.ONCE)
         sched.add_job(job)
         return sched, job
 


### PR DESCRIPTION
## Summary

PRs #19 (model_boundary) and #21 (scheduler) were merged into `main` without including the Copilot review fix commits that were present on the respective feature branches in the DEV repo. This PR applies those missed fixes directly.

### model_boundary.py (from `feat/issue-8-model-boundary` @ `850554a`)

- Tightened allowlist check to exact model name matching (no partial/substring matches)
- Added word-boundary regex for task detection to prevent false positives
- Added spoofing/injection tests to the test suite

### scheduler.py (from `feat/issue-4-scheduler` @ `ebb2e3e`)

- Corrected DOW convention: cron Sunday=0 now maps correctly to Python `weekday()` value 6
- Added `_running_jobs` thread lock for concurrency safety
- Atomic upsert logic to prevent race conditions on job state writes
- Naive datetime normalization (timezone-aware comparisons fixed)
- Cron expression validation on schedule registration

## Test plan

```
python3 -m pytest tests/unit/test_model_boundary.py tests/unit/test_scheduler.py -q --tb=short
```

Expected: **122 passed** (32 model_boundary + 90 scheduler)

Result: 122 passed in 6.53s ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)