### PR TITLE
docs: add safety warning — run in VM/container

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@
 
 ---
 
+> [!WARNING]
+> **Run in a VM or container — do not run on your host machine.**
+>
+> SWE-Squad is an agentic AI system with full access to your filesystem, shell, and git history. Like any tool in this class (Claude Code, Devin, OpenHands, etc.), it can read, write, and execute files autonomously. Running it directly on your workstation or production server exposes your entire filesystem to the agent loop.
+>
+> **Recommended setup:**
+> - 🐳 **Docker** — use the provided `Dockerfile` / `docker-compose.yml` (see [Quick Start](#-quick-start))
+> - 🖥️ **VM** — a dedicated Linux VM (e.g. via VirtualBox, UTM, or a cloud instance) with scoped credentials
+> - ☁️ **Cloud sandbox** — a fresh VPS or GitHub Codespace with only the keys it needs
+>
+> Scope your API keys and GitHub tokens to the minimum required permissions. Never give the agent a token with org-wide write access.
+
+---
+
 ## 🔍 Overview
 
 SWE Squad is a team of AI agents that autonomously monitors your production systems, detects issues, and fixes them — with human oversight at every critical decision point.


### PR DESCRIPTION
## Summary

Adds a prominent `[!WARNING]` block to the README (rendered as a GitHub callout) immediately before the Overview section.

## Why

SWE-Squad — like Claude Code, Devin, OpenHands, and any agentic AI with filesystem + shell access — should not be run directly on a host machine or production server. The agent loop can read, write, and execute files autonomously. New users may not be aware of this risk.

## What it says

- Run in Docker, a dedicated VM, or a cloud sandbox
- Scope API keys and GitHub tokens to minimum required permissions
- Never use org-wide write tokens with the agent

## Test plan

No code changes — README only. Renders correctly as a GitHub warning callout (yellow banner with ⚠️ icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)