### PR TITLE
docs: MkDocs site with GitHub Pages deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ auth_token*
 
 # -----------------------------------------------------------------------------
 # Internal docs — architecture notes, planning docs, roadmaps
+# docs/ is intentionally tracked for MkDocs GitHub Pages site
 # -----------------------------------------------------------------------------
-docs/
 
 # -----------------------------------------------------------------------------
 # Runtime data — tickets, logs, cache

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,115 @@
+# Architecture
+
+## System overview
+
+SWE-Squad is a pipeline of autonomous agents coordinated by a central runner. Each agent is a focused Python module with a single responsibility. Agents communicate via the A2A (Agent-to-Agent) event protocol and share state through the ticket store (JSON or Supabase).
+
+```
+scripts/ops/swe_team_runner.py   — Entry point. Runs one cycle or daemon loop.
+src/swe_team/
+    monitor_agent.py   — Log scanning + fingerprint dedup
+    triage_agent.py    — Severity classification + assignment
+    investigator.py    — Root-cause via Claude CLI + semantic memory
+    developer.py       — Auto-fix: branch → patch → test → keep/discard
+    ralph_wiggum.py    — Stability gate: block/warn/pass
+    governance.py      — Deployment governor, complexity gates
+    ticket_store.py    — JSON file-backed persistence (default)
+    supabase_store.py  — Supabase PostgREST persistence (optional)
+src/a2a/               — A2A protocol: server, client, dispatch, adapters
+```
+
+## Pipeline diagram
+
+```mermaid
+sequenceDiagram
+    participant Runner as swe_team_runner.py
+    participant Mon as MonitorAgent
+    participant Tri as TriageAgent
+    participant Inv as InvestigatorAgent
+    participant Dev as DeveloperAgent
+    participant Gate as RalphWiggum
+    participant Gov as Governance
+
+    Runner->>Mon: scan(log_dirs)
+    Mon-->>Runner: [SWETicket, ...]
+    Runner->>Tri: classify(ticket)
+    Tri-->>Runner: ticket (severity set)
+    Runner->>Inv: investigate(ticket)
+    Inv-->>Runner: ticket (root_cause set)
+    Runner->>Dev: attempt_fix(ticket)
+    Dev-->>Runner: ticket (patch_branch)
+    Runner->>Gate: check()
+    Gate-->>Runner: PASS | WARN | BLOCK
+    Runner->>Gov: pre_deploy_check(ticket)
+    Gov-->>Runner: approved / rejected
+```
+
+## Agent roles
+
+| Agent | Tier | Model | Responsibility |
+|-------|------|-------|----------------|
+| MonitorAgent | — | None | Log scanning, fingerprint dedup |
+| TriageAgent | T1 | gemini-3-flash | Severity + issue type classification |
+| InvestigatorAgent | T2/T3 | sonnet / opus | Root-cause via Claude CLI |
+| DeveloperAgent | T2/T3 | sonnet → opus | Fix, branch, test loop |
+| RalphWiggum | — | None | Error-rate stability gate |
+| Governance | — | None | Complexity + deployment gates |
+| CreativeAgent | T2 | sonnet | Proactive improvement proposals |
+
+## Model routing
+
+```
+Embeddings / fact extraction  →  gemini-3-flash via BASE_LLM proxy
+Routine HIGH bugs             →  claude-sonnet (Claude CLI subprocess)
+CRITICAL bugs                 →  claude-opus  (Claude CLI subprocess)
+After 2 Sonnet failures       →  auto-escalate to opus
+Regression tickets            →  always opus
+Cached fix replay             →  no model (TrajectoryDistiller)
+```
+
+!!! warning "Two-system distinction"
+    `BASE_LLM_API_URL` (OpenAI-compatible HTTP proxy) and the `claude` CLI are **separate systems**.
+    Never call the Claude CLI from library code (`embeddings.py`, `supabase_store.py`).
+    Never call a Claude model name via the BASE_LLM proxy.
+
+## Semantic memory pipeline
+
+```mermaid
+flowchart TD
+    R[Ticket resolved] --> E["extract_memory_facts\ngemini-3-flash"]
+    E --> Em["embed_ticket\nbge-m3 1024-dim"]
+    Em --> D["store_embedding_with_dedup\n0.92 cosine threshold"]
+    D --> S[("Supabase pgvector\nIVFFlat index")]
+
+    S --> F["find_similar\ntop-5 at 0.75 floor\n180-day TTL"]
+    F --> I["Injected into\ninvestigation prompt"]
+    I --> H["record_memory_hit\nconfidence +0.1"]
+```
+
+## A2A hub
+
+SWE Squad registers with a centralized A2A Hub for cross-agent coordination:
+
+```
+LinkedAi A2A Hub: http://100.110.176.73:18790
+├── Protocol: JSON-RPC 2.0 over HTTP POST
+├── Registered agents: openclaw, gemini, llm_proxy, swe-squad
+├── Discovery: GET /health, GET /.well-known/agent-card.json
+└── Events: POST /v1/events
+```
+
+If the hub is unreachable, `src/a2a/dispatch.py` falls back to a local standalone server (`src/a2a/server.py`).
+
+## Remote worker log pipeline
+
+```
+Every monitor cycle:
+  swe_team_runner.py
+    → collect_remote_logs()
+    → rsync -az -e "ssh -F config/ssh_workers.conf"
+    → logs/remote/{worker-name}/*.log
+    → appended to monitor.log_directories
+    → MonitorAgent.scan() picks them up automatically
+```
+
+Workers are configured in `config/swe_team.yaml` under `monitor.remote_workers`. The SSH config at `config/ssh_workers.conf` uses `IdentitiesOnly yes` and a dedicated ed25519 key so only listed workers are reachable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,118 @@
+# Configuration
+
+## Environment variables
+
+All secrets and runtime settings are provided via environment variables (`.env` file or shell). Never hardcode credentials.
+
+Copy `.env.example` to `.env` and fill in the required values:
+
+```bash
+cp .env.example .env
+```
+
+### Required variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SWE_TEAM_ENABLED` | Kill switch (`true`/`false`). Must be `true` to run. |
+| `SWE_TEAM_CONFIG` | Path to `swe_team.yaml` (default: `config/swe_team.yaml`) |
+| `SWE_TEAM_ID` | Unique team identifier for ticket scoping |
+
+### GitHub integration
+
+| Variable | Purpose |
+|----------|---------|
+| `SWE_GITHUB_ACCOUNT` | Bot GitHub account for issue assignment |
+| `SWE_GITHUB_REPO` | Target repo (`owner/repo`) |
+| `GH_TOKEN` | GitHub PAT for `gh` CLI |
+
+### Notifications
+
+| Variable | Purpose |
+|----------|---------|
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token for notifications |
+| `TELEGRAM_CHAT_ID` | Telegram chat ID for alerts |
+| `WEBHOOK_PORT` | GitHub webhook listener port (default: `9876`) |
+| `WEBHOOK_SECRET` | HMAC secret for GitHub webhook signature validation |
+
+### Semantic memory (optional)
+
+| Variable | Purpose |
+|----------|---------|
+| `SUPABASE_URL` | Supabase project URL (enables Supabase store) |
+| `SUPABASE_ANON_KEY` | Supabase anon or service-role key |
+| `BASE_LLM_API_URL` | External OpenAI-compatible proxy (embeddings + extraction) |
+| `BASE_LLM_API_KEY` | API key for BASE_LLM proxy |
+| `EMBEDDING_MODEL` | Embedding model name (default: `bge-m3`) |
+| `EXTRACTION_MODEL` | Fact-extraction model via BASE_LLM (default: `gemini-3-flash`) |
+
+### Model tier overrides
+
+| Variable | Purpose |
+|----------|---------|
+| `SWE_MODEL_T1` | Override T1 model (cheap tasks, default: `haiku`) |
+| `SWE_MODEL_T2` | Override T2 model (routine fixes, default: `sonnet`) |
+| `SWE_MODEL_T3` | Override T3 model (critical/orchestration, default: `opus`) |
+
+### Remote worker access
+
+| Variable | Purpose |
+|----------|---------|
+| `SWE_SSH_CONFIG` | Path to scoped SSH config (default: `config/ssh_workers.conf`) |
+| `SWE_REMOTE_NODES` | JSON array of worker nodes for remote log collection |
+
+## swe_team.yaml
+
+The primary configuration file is `config/swe_team.yaml`. It controls:
+
+- **Agent thresholds** — `max_open_critical`, `max_open_high`, stability gate limits.
+- **Log directories** — local paths scanned by MonitorAgent each cycle.
+- **Remote workers** — SSH aliases, log paths, and worker names.
+- **Model tiers** — T1/T2/T3 model assignments (overridable via env vars).
+- **Fallback agents** — ordered list of fallback CLI agents when Claude is rate-limited.
+- **A2A hub URL** — `a2a_hub_url` for cross-agent coordination.
+- **Scheduler jobs** — cron schedules, quotas, peak-hour windows.
+
+### Remote worker configuration example
+
+```yaml
+monitor:
+  remote_workers:
+    - name: linkedai-browser-2
+      ssh: "linkedai-browser-2"       # must match Host in ssh_workers.conf
+      log_dir: "~/Projects/LinkedAi/logs"
+```
+
+### Fallback agent chain example
+
+```yaml
+fallback_agents:
+  - name: gemini-cli
+    type: gemini
+    model: gemini-2.5-pro
+  - name: opencode
+    type: opencode
+    model: claude-sonnet-4-5
+```
+
+## Cron scheduling
+
+See `crontab.example` for recommended schedules:
+
+```bash
+# Run one full cycle every 5 minutes
+*/5 * * * * /path/to/swe-squad/scripts/ops/swe_team_runner.py
+
+# Daily summary at 09:00
+0 9 * * * python3 scripts/ops/swe_cli.py summary
+```
+
+## Daemon mode
+
+To run the runner as a long-lived daemon (useful for development):
+
+```bash
+python3 scripts/ops/swe_team_runner.py --daemon
+```
+
+The daemon writes its PID to `/tmp/swe_squad_daemon.pid` and logs to `logs/swe_team.log`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,87 @@
+# Contributing to SWE-Squad
+
+Thank you for your interest in contributing to SWE-Squad! This document provides guidelines and information for contributors.
+
+## Getting started
+
+1. **Fork** the repository
+2. **Clone** your fork: `git clone https://github.com/YOUR_USERNAME/SWE-Squad.git`
+3. **Install** dependencies: `pip install python-dotenv pyyaml pytest`
+4. **Configure**: `cp .env.example .env` and fill in test credentials
+5. **Test**: `python3 -m pytest tests/unit/ -q`
+
+## Development workflow
+
+1. Create a feature branch from `main`:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+2. Make your changes
+3. Run the full test suite:
+   ```bash
+   python3 -m pytest tests/unit/ -v --tb=short
+   ```
+   All 827+ tests must pass before committing.
+4. Commit with a descriptive message:
+   ```
+   type(scope): short summary
+   ```
+   Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`.
+5. Push to your fork and open a Pull Request.
+
+## Code style
+
+- **Python 3.10+** with type hints on all function signatures.
+- Use `dataclasses` for all data models — no Pydantic, no attrs.
+- Keep dependencies minimal — prefer stdlib over external packages.
+- No new runtime dependencies without discussion first.
+- Follow existing import patterns: `from src.swe_team.*` and `from src.a2a.*`.
+
+## What we are looking for
+
+### High-priority contributions
+
+- Bug fixes with test coverage
+- Additional ticket store backends (Redis, SQLite)
+- CI/CD pipeline integrations
+- Notification channel plugins (Slack, Discord)
+- Documentation improvements
+
+### Good first issues
+
+- Look for issues labeled [`good first issue`](https://github.com/ArtemisAI/SWE-Squad/labels/good%20first%20issue)
+- Documentation typos and improvements
+- Test coverage for edge cases
+
+## Pull request guidelines
+
+- **One concern per PR** — keep changes focused.
+- **Include tests** for new functionality. Tests live in `tests/unit/` and must use only the standard library plus pytest (no external services required).
+- **Update documentation** if behavior changes.
+- **Keep it minimal** — the smallest change that solves the problem.
+- **No new dependencies** unless absolutely necessary and discussed first.
+- **PR description must include a test plan** — list the test command and expected output.
+
+## Things not to do
+
+- Do not hardcode paths — use `Path(__file__).resolve()` or environment variables.
+- Do not commit `.env`, `*.key`, `*.pem`, or credential files.
+- Do not call the `claude` CLI from library code (`embeddings.py`, `supabase_store.py`, etc.).
+- Do not use `claude-haiku` via the BASE_LLM proxy — it is not available there.
+- Do not break the test suite — run `make test` before committing.
+- Do not push to `main` directly — always open a PR.
+
+## Reporting issues
+
+- Use the [GitHub issue tracker](https://github.com/ArtemisAI/SWE-Squad/issues).
+- Include reproduction steps, expected vs actual behavior.
+- Include relevant logs or error messages.
+- Specify your Python version and OS.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](https://github.com/ArtemisAI/SWE-Squad/blob/main/CODE_OF_CONDUCT.md). By participating, you agree to uphold this code.
+
+## Questions?
+
+Open a [Discussion](https://github.com/ArtemisAI/SWE-Squad/discussions) for questions, ideas, or general conversation about the project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,67 @@
+# SWE-Squad
+
+**Autonomous Software Engineering Agents — self-healing, self-diagnosing development powered by Claude Code**
+
+[![Python](https://img.shields.io/badge/python-3.10+-3776AB?logo=python&logoColor=white)](https://python.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-22C55E)](LICENSE)
+[![GitHub Stars](https://img.shields.io/github/stars/ArtemisAI/SWE-Squad?style=social)](https://github.com/ArtemisAI/SWE-Squad/stargazers)
+
+SWE-Squad is a multi-agent system that monitors your codebase, triages issues, investigates root causes, proposes fixes, and enforces a stability gate — autonomously.
+
+## What it does
+
+```mermaid
+flowchart LR
+    Monitor["Monitor\nLog scanning"] --> Triage["Triage\nSeverity + type"]
+    Triage --> Investigate["Investigate\nRoot cause via Claude"]
+    Investigate --> Develop["Develop\nAuto-fix + branch"]
+    Develop --> Gate["Stability Gate\nRalph Wiggum"]
+    Gate -->|Pass| Deploy["Deploy\nPR + merge"]
+    Gate -->|Block| Human["HITL\nEscalate to human"]
+```
+
+## Quick start
+
+```bash
+git clone https://github.com/ArtemisAI/SWE-Squad.git
+cd SWE-Squad
+pip install pyyaml python-dotenv
+cp .env.example .env  # fill in your keys
+python3 -m pytest tests/unit/ -q  # verify: all tests pass
+python3 scripts/ops/swe_team_runner.py  # run one cycle
+```
+
+## Key features
+
+| Feature | Description |
+|---------|-------------|
+| **Log monitoring** | Scans local + remote logs, deduplicates via fingerprints |
+| **AI investigation** | Claude Sonnet/Opus root-cause analysis with semantic memory |
+| **Auto-fix** | Branch creation, fix attempts, keep/discard loop |
+| **Stability gate** | Blocks deploys when error rate is too high |
+| **RBAC** | Deny-by-default agent permission system |
+| **Scheduler** | Cron-based, quota-aware, peak-hour-aware job runner |
+| **Token tracking** | Per-ticket cost accounting with budget caps |
+| **A2A protocol** | Inter-agent communication hub |
+
+## How it works
+
+Every cycle the runner orchestrates a pipeline:
+
+1. **Monitor** — scans log directories (local and remote SSH workers) for error patterns and creates deduplicated tickets.
+2. **Triage** — classifies each ticket by severity (`LOW`/`MEDIUM`/`HIGH`/`CRITICAL`) and issue type, assigns to an agent.
+3. **Investigate** — runs root-cause analysis via Claude CLI, enriched with semantic memory from past tickets.
+4. **Develop** — attempts an automated fix on a feature branch; runs tests; discards bad patches.
+5. **Stability gate** — Ralph Wiggum blocks new feature work when the error rate exceeds thresholds.
+6. **Govern** — deployment governor checks complexity, token usage, and regression risk before merging.
+
+## Requirements
+
+- Python 3.10+
+- `pyyaml`, `python-dotenv` (core — no other mandatory runtime deps)
+- `claude` CLI (Anthropic Claude Code) in `PATH`
+- Optional: Supabase account (semantic memory), Telegram bot (notifications)
+
+## License
+
+MIT — see [LICENSE](https://github.com/ArtemisAI/SWE-Squad/blob/main/LICENSE).

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,0 +1,77 @@
+# Module Reference
+
+All modules live under `src/swe_team/`. Each is a focused Python module with a single responsibility. The system has no mandatory runtime dependencies beyond `pyyaml` and `python-dotenv`.
+
+## Core pipeline modules
+
+| Module | Description |
+|--------|-------------|
+| `monitor_agent.py` | Scans configured log directories for error patterns, de-duplicates against recently filed tickets via fingerprints, and creates `SWETicket` items for new issues. |
+| `triage_agent.py` | Receives `ISSUE_DETECTED` events or raw `SWETicket` objects, classifies by severity and module, and assigns to the appropriate agent tier. |
+| `investigator.py` | Runs root-cause analysis via the Claude Code CLI and attaches the resulting report to the ticket. Injects semantic memory context from past similar tickets. |
+| `developer.py` | Uses a keep/discard loop with git as the state machine to attempt fixes and only keep changes that pass tests and complexity gates. |
+| `ralph_wiggum.py` | Implements the stability-first governance pattern — fix bugs before building new features. Evaluates error rate, open ticket backlog, and regression risk to return `PASS`, `WARN`, or `BLOCK`. |
+| `governance.py` | Provides deployment rules, rollback logic, and integration checks. Works alongside Ralph Wiggum to enforce CI/CD gates. |
+
+## Storage modules
+
+| Module | Description |
+|--------|-------------|
+| `ticket_store.py` | JSON file-backed persistent ticket store. Lightweight default with fingerprint dedup tracking. Drop-in interface compatible with `supabase_store.py`. |
+| `supabase_store.py` | Supabase PostgREST-backed ticket store. Drop-in replacement with semantic dedup (cosine similarity), confidence weighting, and pgvector search. Zero extra dependencies — uses only `urllib`. |
+
+## Intelligence modules
+
+| Module | Description |
+|--------|-------------|
+| `embeddings.py` | Embedding helper for semantic memory. Calls the BASE_LLM proxy (bge-m3 by default) and returns `None` on failure so callers treat semantic memory as best-effort. |
+| `distiller.py` | Trajectory distiller — stores deterministic fix automations keyed by error fingerprint so repeated issues are resolved without re-running LLM investigations. |
+| `creative_agent.py` | Analyzes resolved ticket patterns and proposes low-severity improvements. Only runs when the stability gate is passing. |
+
+## Infrastructure modules
+
+| Module | Description |
+|--------|-------------|
+| `config.py` | Loads `config/swe_team.yaml` plus environment variable overrides. Provides the `ModelTiers` dataclass for T1/T2/T3 model routing. |
+| `models.py` | Core dataclasses: `SWETicket`, `TicketSeverity`, `TicketStatus`, `IssueType`, and related enums. |
+| `events.py` | SWE-team-specific pipeline events extending the core A2A `EventType` vocabulary. |
+| `preflight.py` | `PreflightCheck` validates git identity, clean tree, and required env vars before any developer or investigator action. |
+| `scheduler.py` | Cron-based, quota-aware, peak-hour-aware job runner. Supports 5-field cron expressions and per-job quota limits. |
+| `rate_limiter.py` | Rate-limit detection and exponential backoff for Claude Code CLI calls. Provides `ExponentialBackoff` retry wrapper. |
+| `session.py` | Session tagging for end-to-end tracing across logs, GitHub comments, and Supabase records. |
+
+## Security & RBAC modules
+
+| Module | Description |
+|--------|-------------|
+| `agent_rbac.py` | Role-Based Access Control for SWE-Squad agents. Loads role definitions from `config/swe_team/roles.yaml`. Deny-by-default: any permission not explicitly granted is denied. |
+| `model_boundary.py` | SEC-68 model boundary enforcement. Ensures only approved Claude models are used for code generation tasks. Blocks unauthorized model substitution. |
+
+## Notification & integration modules
+
+| Module | Description |
+|--------|-------------|
+| `notifier.py` | Sends Telegram alerts for new high/critical tickets, stability gate blocks, and daily summaries. |
+| `telegram.py` | Standalone Telegram Bot API client using only stdlib (`urllib`). Reads credentials from environment variables. Zero external dependencies. |
+| `github_integration.py` | Creates and manages GitHub issues from SWE tickets using the `gh` CLI. Repo-aware: reads repo from `ticket.metadata['repo']`. |
+| `remote_logs.py` | Collects logs from remote worker machines via SSH/rsync. Maps source modules to workers for targeted log fetching during investigation. |
+
+## A2A protocol (`src/a2a/`)
+
+| Module | Description |
+|--------|-------------|
+| `src/a2a/server.py` | Lightweight standalone A2A HTTP server for when the hub is unreachable. |
+| `src/a2a/client.py` | A2A client supporting both hub mode (centralized) and direct agent mode. |
+| `src/a2a/dispatch.py` | Event dispatcher — POSTs to the centralized hub with fallback to standalone log. |
+| `src/a2a/adapters/` | Agent adapters for Gemini CLI, OpenCode, generic CLI, and SWE-Team itself. |
+
+## Ops scripts
+
+Additional operational scripts live under `src/swe_team/ops/` and `scripts/ops/`:
+
+- `swe_team_runner.py` — Main entry point; runs one cycle or daemon loop.
+- `swe_cli.py` — CLI tool: `status`, `tickets`, `issues`, `repos`, `summary`, `report`.
+- `dashboard_data.py` — Dashboard metrics generator writing `data/swe_team/status.json`.
+- `a2a_hub.py` — Standalone A2A hub entry point.
+- `webhook_listener.py` — GitHub webhook listener (port 9876) for push-triggered propagation.
+- `propagate.sh` — Parallel SSH code propagation to all worker nodes (~4 seconds).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,58 @@
+# Security
+
+## Model boundary enforcement
+
+SWE-Squad enforces strict boundaries on which models may perform code generation tasks.
+
+**SEC-68 pattern**: The `model_boundary.py` module prevents unauthorized model substitution. Only approved Claude models are permitted for code generation. Any attempt to use a non-Claude model for code generation is blocked at the boundary check.
+
+This protects against scenarios where a connected agent (via A2A) could route code generation tasks to an unapproved model without operator awareness.
+
+The boundary is enforced in `developer.py` and `investigator.py` before every Claude CLI call.
+
+## Role-Based Access Control (RBAC)
+
+SWE-Squad uses a deny-by-default RBAC system defined in `config/swe_team/roles.yaml`.
+
+- **Deny-by-default**: any permission not explicitly granted is denied.
+- **Role definitions**: each agent role lists the operations it is allowed to perform (e.g., `create_branch`, `push_commit`, `create_github_issue`).
+- **Enforcement point**: `agent_rbac.py` is called at every pipeline stage transition.
+
+The RBAC system prevents privilege escalation — a triage agent cannot perform developer actions, and a developer agent cannot modify governance thresholds.
+
+## SSH security model
+
+Remote worker access uses a scoped SSH configuration:
+
+- `config/ssh_workers.conf` — `IdentitiesOnly yes`, Host entries for each worker.
+- `~/.ssh/swe_workers_linkedai_key` — Dedicated ed25519 key for workers only.
+
+Only workers listed in `ssh_workers.conf` are reachable via the dedicated key. The primary orchestrator node is explicitly excluded from `authorized_keys` on workers — agents cannot reach "up" the hierarchy.
+
+## Secrets management
+
+- All secrets are provided via `.env` or environment variables — never hardcoded.
+- The files `.env`, `*.key`, `*.pem`, and any credentials files are `.gitignore`d.
+- Any key that appears in a diff or log must be rotated immediately.
+- `GH_TOKEN` is stripped from subprocess environments before passing to worker processes.
+
+## GitHub webhook validation
+
+The webhook listener (`scripts/ops/webhook_listener.py`) validates all incoming GitHub webhooks using HMAC-SHA256 signature verification against `WEBHOOK_SECRET`. Requests with invalid or missing signatures are rejected with HTTP 403.
+
+## Preflight checks
+
+Before any investigator or developer action, `preflight.py` validates:
+
+- **Git identity**: the configured committer name and email match expected values.
+- **Clean working tree**: no uncommitted changes that could corrupt the patch/discard loop.
+- **Required env vars**: all necessary variables are present before the agent proceeds.
+
+Failing preflight causes the ticket to be held rather than proceeding with a potentially unsafe action.
+
+## Audit trail
+
+- Every cycle writes `data/swe_team/status.json` for observability.
+- Every A2A event is logged to the hub and local fallback.
+- Every investigation and fix attempt is attached to the ticket record in Supabase.
+- Session tags (from `session.py`) provide end-to-end tracing across logs, GitHub comments, and Supabase records.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,47 @@
+site_name: SWE-Squad
+site_description: Autonomous Software Engineering Agents — self-healing, self-diagnosing development team powered by Claude Code
+site_url: https://artemisai.github.io/SWE-Squad
+repo_url: https://github.com/ArtemisAI/SWE-Squad
+repo_name: ArtemisAI/SWE-Squad
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: orange
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: orange
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - search.highlight
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Architecture: architecture.md
+  - Modules: modules.md
+  - Configuration: configuration.md
+  - Security: security.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - admonition
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary

- Adds a full MkDocs Material documentation site deployable to GitHub Pages at `https://artemisai.github.io/SWE-Squad`
- Closes the docs gap from DEV PR #62 (ported content from `origin/copilot/create-docs-folder-and-agents-md` and module docstrings)
- Removes the `docs/` gitignore entry that was blocking the site from being tracked

## Files added

| File | Purpose |
|------|---------|
| `mkdocs.yml` | MkDocs Material config — tabs, search, code copy, mermaid, dark/light toggle |
| `docs/index.md` | Landing page with quickstart, feature table, pipeline overview |
| `docs/architecture.md` | System overview, sequenceDiagram, agent roles, model routing, semantic memory, A2A hub |
| `docs/modules.md` | Full module reference for all `src/swe_team/` and `src/a2a/` modules (descriptions sourced from actual docstrings) |
| `docs/configuration.md` | Complete env vars table, `swe_team.yaml` guide, cron scheduling, daemon mode |
| `docs/security.md` | SEC-68 model boundary, RBAC, SSH security model, secrets, webhook validation, preflight, audit trail |
| `docs/contributing.md` | Dev workflow, code style, PR guidelines, things not to do |
| `.gitignore` | Removed `docs/` exclusion so the MkDocs source can be tracked |

## GitHub Actions deploy workflow

`.github/workflows/docs.yml` (needs `workflow` PAT scope — add manually or grant scope to bot):
- Triggers on push to `main` when `docs/**` or `mkdocs.yml` changes, plus `workflow_dispatch`
- Installs `mkdocs-material` and runs `mkdocs gh-deploy --force`
- Uses `contents: write` permission to push to `gh-pages` branch

**Note**: The workflow file could not be pushed via the API token (requires `workflow` scope). Please add it manually after merging, or update the bot PAT with `workflow` scope and re-push.

## Test plan

```bash
pip install mkdocs-material
mkdocs build --strict   # should complete with no errors
mkdocs serve            # preview at http://127.0.0.1:8000
```

After merge, enable GitHub Pages in repo Settings → Pages → Source: `gh-pages` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)